### PR TITLE
Feat : 문서 콘텐츠 저장 시, 썸네일 추가 (#8)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/content/domain/Document.java
+++ b/src/main/java/com/adoonge/seedzip/content/domain/Document.java
@@ -9,6 +9,7 @@ import lombok.*;
 
 @Getter
 @Builder
+@Setter
 @Entity
 @Table(name = "document")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,6 +21,9 @@ public class Document extends BaseEntity {
 
     @Column(nullable = false, length = 1000)
     private String docLink;
+
+    @Column(nullable = false)
+    private boolean docThumbnail = false;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "contents_id")

--- a/src/main/java/com/adoonge/seedzip/content/repository/DocumentRepository.java
+++ b/src/main/java/com/adoonge/seedzip/content/repository/DocumentRepository.java
@@ -1,6 +1,7 @@
 package com.adoonge.seedzip.content.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import com.adoonge.seedzip.content.domain.Document;
 import com.adoonge.seedzip.content.domain.Image;
@@ -13,6 +14,9 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DocumentRepository extends JpaRepository<Document, Long> {
+
+	@Query("SELECT i FROM Document i WHERE i.contents.contentsId = :contentsId AND i.docThumbnail = :docThumbnail")
+	Optional<Document> findByContentsIdAndDocThumbnail(Long contentsId, boolean docThumbnail);
 
 	List<Document> findAllByContents_ContentsId(Long contentsId);
 

--- a/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
+++ b/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
@@ -183,6 +183,13 @@ public class ContentsService {
 						thumbnailUrl = thumbnailImage.get().getImgLink();
 					}
 				}
+				else if(ContentsDataType.PDF.equals(content.getContentsDataType())) {
+					Optional<Document> thumbnailDoc = documentRepository.findByContentsIdAndDocThumbnail(
+							content.getContentsId(), true);
+					if (thumbnailDoc.isPresent()) {
+						thumbnailUrl = thumbnailDoc.get().getDocLink();
+					}
+				}
 				// contentId에 해당하는 카테고리 리스트 조회
 				List<Long> categoryIds = categoryContentRepository.findCategoryIdsByContentId(content.getContentsId());
 				List<String> categoryNames = categoryIds.stream()
@@ -341,9 +348,16 @@ public class ContentsService {
 
 			List<Document> documentList = documentRepository.findAllByContents_ContentsId(contents.getContentsId());
 
+			int idx = 0;
 			for (Document document : documentList) {
 				// 이미지 URL 추가
 				contentDoc.add(document.getDocLink());
+
+				if (document.isDocThumbnail()) {
+					thumbnailImage = (long) idx;
+				}
+
+				idx++;
 			}
 		}
 

--- a/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
+++ b/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
@@ -104,6 +104,10 @@ public class ContentsService {
 
 		if (request.getDataType().equals(ContentsDataType.PDF)) {
 			// PDF
+
+			AtomicInteger index = new AtomicInteger(0); // 현재 인덱스를 추적하기 위한 변수
+			int thumbnailIndex = request.getThumbnailImage();
+
 			files.stream().forEach(file -> {
 				try {
 					// S3에 파일 업로드 및 URL 가져오기
@@ -112,6 +116,14 @@ public class ContentsService {
 
 					// URL 저장
 					Document document = documentRepository.save(request.toDocEntity(contents, fileUrl));
+
+					if (index.get() == thumbnailIndex) {
+						document.setDocThumbnail(true);
+					}
+
+					documentRepository.save(document);
+					index.getAndIncrement();
+
 				} catch (IOException e) {
 					e.printStackTrace();
 				}


### PR DESCRIPTION
## 🪺 Summary
- 콘텐츠 (문서) 저장 시, 썸네일 인덱스도 저장하도록 변수를 추가했습니다
- 콘텐츠 (문서) 저장 시, 썸네일도 지정하도록 추가했습니다

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #8 

## 🙏 To Reviewers
