### PR TITLE
Feat : 카테고리 관련 수정 (#5)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/category/domain/Category.java
+++ b/src/main/java/com/adoonge/seedzip/category/domain/Category.java
@@ -18,7 +18,6 @@ import jakarta.persistence.Table;
 import lombok.*;
 
 @Getter
-@Setter
 @Builder
 @Entity
 @Table(name = "category")
@@ -34,7 +33,7 @@ public class Category extends BaseEntity {
 	private String name;
 
 	@Enumerated(EnumType.STRING)
-	@Column(nullable = false)
+	@NonNull
 	private Visibility visibility;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
+++ b/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
@@ -66,6 +66,11 @@ public class CategoryService {
 			throw SeedzipException.from(ErrorCode.CATEGORY_ACCESS_DENIED);
 		}
 
+		// 디폴트 카테고리 삭제 불가
+		if (id == 1L) {
+			throw SeedzipException.from(ErrorCode.CATEGORY_CANNOT_BE_DELETED);
+		}
+
 		categoryRepository.delete(category);
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
+++ b/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
@@ -15,24 +15,23 @@ import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
 
 import jakarta.transaction.Transactional;
+import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
-@RequiredArgsConstructor
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 @Service
 @Slf4j
+@Transactional
 public class CategoryService {
 
 	private final CategoryRepository categoryRepository;
 
-	@Transactional
 	public CategoryResponse createCategory(AddCategoryRequest request, Member member) {
 		Category category = categoryRepository.save(request.toEntity(member));
 		return CategoryResponse.fromEntity(category);
 	}
 
-
-	@Transactional
 	public CategoryResponse updateCategory(Long id, UpdateCategoryRequest request, Member member) {
 		Category category = categoryRepository.findById(id)
 			.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND));
@@ -50,7 +49,7 @@ public class CategoryService {
 		return CategoryResponse.fromEntity(category);
 	}
 
-	public List<CategoryResponse> getCategories(Member member){
+	public List<CategoryResponse> getCategories(Member member) {
 		List<Category> categories = categoryRepository.findByMemberId(member.getId());
 
 		return categories.stream()
@@ -58,8 +57,7 @@ public class CategoryService {
 			.collect(Collectors.toList());
 	}
 
-	@Transactional
-	public void deleteCategory(Long id, Member member){
+	public void deleteCategory(Long id, Member member) {
 		Category category = categoryRepository.findById(id)
 			.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND));
 

--- a/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
+++ b/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
@@ -10,6 +10,8 @@ import com.adoonge.seedzip.category.dto.request.AddCategoryRequest;
 import com.adoonge.seedzip.category.dto.request.UpdateCategoryRequest;
 import com.adoonge.seedzip.category.dto.response.CategoryResponse;
 import com.adoonge.seedzip.category.repository.CategoryRepository;
+import com.adoonge.seedzip.content.domain.Contents;
+import com.adoonge.seedzip.content.repository.ContentsRepository;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
@@ -26,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class CategoryService {
 
 	private final CategoryRepository categoryRepository;
+	private final ContentsRepository contentsRepository;
 
 	public CategoryResponse createCategory(AddCategoryRequest request, Member member) {
 		Category category = categoryRepository.save(request.toEntity(member));
@@ -71,6 +74,12 @@ public class CategoryService {
 			throw SeedzipException.from(ErrorCode.CATEGORY_CANNOT_BE_DELETED);
 		}
 
+		// category, category_content 삭제
 		categoryRepository.delete(category);
+		categoryRepository.flush();	// 실행 순서 보장
+
+		// 콘텐츠에서 참조되지 않는 항목을 삭제 (배치 처리)
+		contentsRepository.deleteUnreferencedContents();
+
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/content/repository/ContentsRepository.java
+++ b/src/main/java/com/adoonge/seedzip/content/repository/ContentsRepository.java
@@ -2,14 +2,23 @@ package com.adoonge.seedzip.content.repository;
 
 import com.adoonge.seedzip.content.domain.Contents;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+
+import jakarta.transaction.Transactional;
 
 @Repository
 public interface ContentsRepository extends JpaRepository<Contents, Long> {
     Contents findByContentsId(Long contentsId);
     List<Contents> findByMemberId(Long memberId);
     List<Contents> findByContentsIdIn(List<Long> contentIds);
+
+    @Transactional
+    @Modifying
+    @Query("DELETE FROM Contents c WHERE NOT EXISTS (SELECT 1 FROM CategoryContent cc WHERE cc.contents.contentsId = c.contentsId)")
+    void deleteUnreferencedContents();
 }

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
 
     // category
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+    CATEGORY_CANNOT_BE_DELETED(HttpStatus.BAD_REQUEST, "이 카테고리는 삭제할 수 없습니다."),
     CATEGORY_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 동일한 이름의 카테고리가 존재합니다."),
     CATEGORY_ACCESS_DENIED(HttpStatus.FORBIDDEN, "이 카테고리에 대한 접근 권한이 없습니다."),
     CATEGORY_BOOKMARK_NOT_ALLOWED(HttpStatus.FORBIDDEN, "이 카테고리는 북마크할 수 없습니다."),


### PR DESCRIPTION
## 🪺 Summary
- 1번 카테고리를 디폴트로 지정하고 삭제 불가능하도록 했습니다.
- 카테고리 삭제 후 참조하는 카테고리가 없는 콘텐츠도 삭제되도록 로직 추가했습니다.
- 아래 이미지에서 마지막 테이블이 2번 카테고리 삭제 수행 후 입니다!
<img width="1089" alt="스크린샷 2024-11-21 오후 8 42 25" src="https://github.com/user-attachments/assets/6d8a6b17-976b-4d8a-8514-4ae069c0d64c">


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #5 


## 🙏 To Reviewers
