### PR TITLE
Refactor: 이미지 관련 추천시  아닌 이미지 링크가 아닌, 이미지 자체를 받도록 리팩토링 (#56)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
@@ -1,17 +1,24 @@
 package com.adoonge.seedzip.recommendation.controller;
 
+import com.adoonge.seedzip.auth.util.CustomUserDetails;
 import com.adoonge.seedzip.global.dto.response.ApiResponse;
 import com.adoonge.seedzip.recommendation.dto.response.RecommendationResponse;
 import com.adoonge.seedzip.recommendation.service.RecommendationService;
 import com.adoonge.seedzip.recommendation.service.YouTubeService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/recommendation")
@@ -23,10 +30,11 @@ public class RecommendationController {
 
     private final YouTubeService youTubeService;
 
-    @PostMapping("/image")
+    @PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "이미지 추천 관련 API", description = "이미지 링크를 넣으면 제목, 요약, 태그를 추천해주는 API입니다.")
-    public ApiResponse<RecommendationResponse> imageAnalysis(@RequestParam String imageUrl) {
-        RecommendationResponse response = recommendationService.requestImageAnalysis(imageUrl);
+    public ApiResponse<RecommendationResponse> imageAnalysis(@Parameter(description = "업로드할 이미지", content = @Content(mediaType = "application/octet-stream"))
+                                                                 @RequestParam(value = "file", required = false) MultipartFile file) {
+        RecommendationResponse response = recommendationService.requestImageAnalysis(file);
         return new ApiResponse<>(response);
     }
 

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
@@ -11,9 +11,11 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.codec.binary.Base64;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -42,9 +44,14 @@ public class RecommendationService {
         }
     }
 
-    public RecommendationResponse requestImageAnalysis(String imageUrl)  {
-//        String base64Image = Base64.encodeBase64String(image.getBytes());
-//        String imageUrl = "data:image/jpeg;base64," + base64Image;
+    public RecommendationResponse requestImageAnalysis(MultipartFile file)  {
+        String base64Image;
+        try {
+            base64Image = Base64.encodeBase64String(file.getBytes());
+        } catch (IOException e) {
+            throw SeedzipException.from(ErrorCode.INTERNAL_SEVER_ERROR);
+        }
+        String imageUrl = "data:image/jpeg;base64," + base64Image;
         ChatGPTRequest request = ChatGPTRequest.createImageRequest(apiModel, 500, imageUrl);
         ChatGPTResponse chatGPTResponse =  template.postForObject(apiUrl, request, ChatGPTResponse.class);
 


### PR DESCRIPTION
## 🪺 Summary
원래는 이미지 관련 추천시 인식 가능한 이미지 링크를 받아 GPT로 요청을 받았지만,
MultipartFile로 이미지를 직접 받아 이미지 데이터를 Base64 형식으로 인코딩하고 이를 Data URL로 변환하여 GPT에 요청을 보내는 방식으로 리팩토링했습니다!

### 예시
![t1](https://github.com/user-attachments/assets/cba96fe4-d379-4e8d-ba9e-a85e8f1d649a)
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/c789f9c6-7d6d-420c-b198-11d53a77b1de" />


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #56 


## 🙏 To Reviewers
