### PR TITLE
Feat : 네이버 뉴스 요약 api 구현 #88

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
 	// PDFBox
 	implementation 'org.apache.pdfbox:pdfbox:2.0.24'
+
+	//Jsoup
+	implementation 'org.jsoup:jsoup:1.15.4'
 }
 
 bootJar {

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package com.adoonge.seedzip.global.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
@@ -102,7 +103,10 @@ public enum ErrorCode {
     FILTER_QUOTA_EXCEEDED(HttpStatus.PAYLOAD_TOO_LARGE, "필터 저장 한도를 초과했습니다."),
     FILTER_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "필터 생성에 실패했습니다."),
     FILTER_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "필터 유효성 검사가 실패했습니다."),
-    FILTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "이 필터에 대한 접근 권한이 없습니다.");
+    FILTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "이 필터에 대한 접근 권한이 없습니다."),
+
+    // recommendation
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
@@ -57,7 +57,7 @@ public class RecommendationController {
     @PostMapping(value = "/naver-news")
     @Operation(summary = "네이버 뉴스 추천 관련 API", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 추천해주는 API입니다.")
     public ApiResponse<RecommendationResponse> naverNewsAnalysis(@RequestParam String naverNewsUrl) throws IOException {
-        recommendationService.requestNaverNewsAnalysis(naverNewsUrl);
-        return null;
+        RecommendationResponse recommendationResponse = recommendationService.requestNaverNewsAnalysis(naverNewsUrl);
+        return new ApiResponse<>(recommendationResponse);
     }
 }

--- a/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/controller/RecommendationController.java
@@ -53,4 +53,11 @@ public class RecommendationController {
         RecommendationResponse recommendationResponse = recommendationService.requestPdfAnalysis(file);
         return new ApiResponse<>(recommendationResponse);
     }
+
+    @PostMapping(value = "/naver-news")
+    @Operation(summary = "네이버 뉴스 추천 관련 API", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 추천해주는 API입니다.")
+    public ApiResponse<RecommendationResponse> naverNewsAnalysis(@RequestParam String naverNewsUrl) throws IOException {
+        recommendationService.requestNaverNewsAnalysis(naverNewsUrl);
+        return null;
+    }
 }

--- a/src/main/java/com/adoonge/seedzip/recommendation/dto/request/ChatGPTRequest.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/dto/request/ChatGPTRequest.java
@@ -44,6 +44,12 @@ public class ChatGPTRequest {
         return createChatGPTRequest(model, maxTokens, List.of(systemMessage,userMessage));
     }
 
+    public static ChatGPTRequest createNewsRequest(String model, int maxTokens, String requestText) {
+        Message systemMessage = new TextMessage("system", "You are a helpful assistant for generating hashtags for news. Please answer in Korean.");
+        Message userMessage = new TextMessage("user", "Analyze the given text about a news, suggest a title, provide a 3-sentence summary, and 3 tags as a comma-separated string without #. Return the result as a raw JSON object without any code block or additional formatting.\n" + requestText);
+        return createChatGPTRequest(model, maxTokens, List.of(systemMessage,userMessage));
+    }
+
     private static ChatGPTRequest createChatGPTRequest(String model, int maxTokens, List<Message> messages) {
         return ChatGPTRequest.builder()
                 .model(model)

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/NaverNewsService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/NaverNewsService.java
@@ -1,0 +1,65 @@
+package com.adoonge.seedzip.recommendation.service;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NaverNewsService {
+
+	@Value("${X_NAVER_CLIENT_ID}")
+	private String X_NAVER_CLIENT_ID;
+
+	@Value("${X_NAVER_CLIENT_SECRET}")
+	private String X_NAVER_CLIENT_SECRET;
+
+	public String searchNews(String title) throws UnsupportedEncodingException {
+		String encoded = parseUrl(title);	// 검색어 인코딩
+		log.info(encoded);
+
+		// URI 설정
+		String apiUrl = "https://openapi.naver.com/v1/search/news.json" +
+			"?query=" + encoded +
+			"&display=1" +
+			"&start=1" +
+			"&sort=sim";
+
+		URI uri = URI.create(apiUrl);
+
+		// 헤더 설정
+		RequestEntity<Void> req = RequestEntity
+			.get(uri)
+			.header("X-Naver-Client-Id", X_NAVER_CLIENT_ID)
+			.header("X-Naver-Client-Secret", X_NAVER_CLIENT_SECRET)
+			.header("User-Agent", "curl/7.49.1")
+			.header("Accept", "*/*")
+			.header("Host", "openapi.naver.com")
+			.build();
+
+		RestTemplate restTemplate = new RestTemplate();
+		ResponseEntity<String> response = restTemplate.exchange(req, String.class);
+
+		String body = response.getBody();
+		return null;
+	}
+
+	private String parseUrl(String title) throws UnsupportedEncodingException {
+
+		return URLEncoder.encode(title, StandardCharsets.UTF_8)
+			.replace("+", "%20");
+	}
+
+
+}

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/NaverNewsService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/NaverNewsService.java
@@ -52,7 +52,7 @@ public class NaverNewsService {
 		ResponseEntity<String> response = restTemplate.exchange(req, String.class);
 
 		String body = response.getBody();
-		return null;
+		return body;
 	}
 
 	private String parseUrl(String title) throws UnsupportedEncodingException {

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
@@ -10,12 +10,15 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 
+import jdk.jfr.consumer.RecordedObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.commons.codec.binary.Base64;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.text.PDFTextStripper;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
@@ -33,6 +36,7 @@ public class RecommendationService {
     private String apiUrl;
 
     private final RestTemplate template;
+    private final NaverNewsService naverNewsService;
 
     public RecommendationResponse requestTextAnalysis(String requestText) {
         ChatGPTRequest request = ChatGPTRequest.createYoutubeRequest(apiModel, 500, requestText);
@@ -68,6 +72,16 @@ public class RecommendationService {
         }
     }
 
+    // 네이버 뉴스 분석 요청
+    public RecommendationResponse requestNaverNewsAnalysis(String naverNewsUrl) throws IOException {
+        // 네이버 뉴스 제목 가져오기
+        String newsTitle = getNewsTitle(naverNewsUrl);
+
+        String newsDescription = naverNewsService.searchNews(newsTitle);
+
+        return null;
+    }
+
     public RecommendationResponse requestPdfAnalysis(MultipartFile file) throws IOException {
         ChatGPTRequest pdfRequest = ChatGPTRequest.createPdfRequest(apiModel, 500, extractTextFromPdf(file));
 
@@ -99,5 +113,10 @@ public class RecommendationService {
             throw SeedzipException.from(ErrorCode.INTERNAL_SEVER_ERROR);
         }
 
+    }
+
+    private String getNewsTitle(String naverNewsUrl) throws IOException {
+        Document document = Jsoup.connect(naverNewsUrl).get();
+        return document.title();
     }
 }

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
@@ -78,8 +78,18 @@ public class RecommendationService {
         String newsTitle = getNewsTitle(naverNewsUrl);
 
         String newsDescription = naverNewsService.searchNews(newsTitle);
+        log.info(newsDescription);
 
-        return null;
+        ChatGPTRequest newsRequest = ChatGPTRequest.createNewsRequest(apiModel, 500, newsDescription);
+        ChatGPTResponse chatGPTResponse = template.postForObject(apiUrl, newsRequest, ChatGPTResponse.class);
+        String response = chatGPTResponse.getChoices().get(0).getMessage().getContent();
+
+        try{
+            return parseRecommendationResponse(response);
+        } catch (JsonProcessingException e) {
+            throw SeedzipException.from(ErrorCode.INTERNAL_SEVER_ERROR);
+        }
+
     }
 
     public RecommendationResponse requestPdfAnalysis(MultipartFile file) throws IOException {

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
@@ -39,10 +39,6 @@ public class RecommendationService {
     private final NaverNewsService naverNewsService;
 
     public RecommendationResponse requestTextAnalysis(String requestText) {
-        if(!requestText.contains("https://www.youtube.com/watch?v=")){
-            throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
-        }
-
         ChatGPTRequest request = ChatGPTRequest.createYoutubeRequest(apiModel, 500, requestText);
 
         ChatGPTResponse chatGPTResponse = template.postForObject(apiUrl, request, ChatGPTResponse.class);
@@ -86,7 +82,6 @@ public class RecommendationService {
         String newsTitle = getNewsTitle(naverNewsUrl);
 
         String newsDescription = naverNewsService.searchNews(newsTitle);
-        log.info(newsDescription);
 
         ChatGPTRequest newsRequest = ChatGPTRequest.createNewsRequest(apiModel, 500, newsDescription);
         ChatGPTResponse chatGPTResponse = template.postForObject(apiUrl, newsRequest, ChatGPTResponse.class);
@@ -137,4 +132,5 @@ public class RecommendationService {
         Document document = Jsoup.connect(naverNewsUrl).get();
         return document.title();
     }
+
 }

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/RecommendationService.java
@@ -39,6 +39,10 @@ public class RecommendationService {
     private final NaverNewsService naverNewsService;
 
     public RecommendationResponse requestTextAnalysis(String requestText) {
+        if(!requestText.contains("https://www.youtube.com/watch?v=")){
+            throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         ChatGPTRequest request = ChatGPTRequest.createYoutubeRequest(apiModel, 500, requestText);
 
         ChatGPTResponse chatGPTResponse = template.postForObject(apiUrl, request, ChatGPTResponse.class);
@@ -74,6 +78,10 @@ public class RecommendationService {
 
     // 네이버 뉴스 분석 요청
     public RecommendationResponse requestNaverNewsAnalysis(String naverNewsUrl) throws IOException {
+        if(!naverNewsUrl.contains("https://n.news.naver.com")) {
+            throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+        }
+
         // 네이버 뉴스 제목 가져오기
         String newsTitle = getNewsTitle(naverNewsUrl);
 

--- a/src/main/java/com/adoonge/seedzip/recommendation/service/YouTubeService.java
+++ b/src/main/java/com/adoonge/seedzip/recommendation/service/YouTubeService.java
@@ -3,6 +3,8 @@ package com.adoonge.seedzip.recommendation.service;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.google.api.services.youtube.YouTube;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.youtube.model.SearchListResponse;
@@ -25,6 +27,10 @@ public class YouTubeService {
 
     // url로 비디오 검색하는 함수
     public String searchVideos(String query) throws IOException {
+        // 유효하지 않은 URL인 경우 예외 처리
+        if(!query.contains("https://www.youtube.com/watch?v=")){
+            throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+        }
 
         JacksonFactory jacksonFactory = new JacksonFactory();
 


### PR DESCRIPTION
## 🪺 Summary
네이버 뉴스 url (https://n.news.naver.com/....)를 받은 후 기사의 제목을 추출합니다.
추출한 제목을 파라미터로 naver 뉴스 api를 호출하여 요약정보를 받은 후 openai를 사용해 제목, 요약, 태그를 추천받습니다.

<img width="777" alt="스크린샷 2024-12-30 오후 7 11 51" src="https://github.com/user-attachments/assets/481177d8-f9d2-4f64-8b12-1de2040b7a76" />
<img width="1096" alt="스크린샷 2024-12-30 오후 7 12 03" src="https://github.com/user-attachments/assets/ca80b147-4705-4e27-8ee7-03f9209c9d56" />


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #56 


## 🙏 To Reviewers
