### PR TITLE
Refactor: 소셜 로그인 리팩토링 (#118)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
+++ b/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -35,13 +36,14 @@ public class AuthController {
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "테스트용 기본 로그인 API입니다.")
     public ApiResponse<LoginResponse> login(@RequestParam String code, HttpServletResponse response) {
-        return authService.login(code, SocialType.BASIC, response);
+        return authService.login(code, "BASIC", response);
     }
 
-    @PostMapping("/login/kakao")
-    @Operation(summary = "카카오 로그인 API", description = "카카오 인가코드를 받고 JWT 토큰을 리턴합니다.")
-    ApiResponse<LoginResponse> loginKakao(@RequestParam String code, HttpServletResponse response) {
-        return authService.login(code, SocialType.KAKAO, response);
+
+    @PostMapping("/login/{socialType}")
+    @Operation(summary = "소셜 로그인 API", description = "소셜 인가코드를 받고 JWT 토큰을 리턴합니다. socialType -> {KAKAO, NAVER, GOOGLE}")
+    ApiResponse<LoginResponse> socialLogin(@RequestParam String code, @PathVariable String socialType, HttpServletResponse response) {
+        return authService.login(code, socialType.toUpperCase(), response);
     }
 
     @PostMapping("/login/kakao/app")
@@ -50,11 +52,7 @@ public class AuthController {
         return authService.loginForApp(accessToken, SocialType.KAKAO, response);
     }
 
-    @PostMapping("/login/naver")
-    @Operation(summary = "네이버 로그인 API", description = "네이버 인가코드를 받고 JWT 토큰을 리턴합니다.")
-    ApiResponse<LoginResponse> loginNaver(@RequestParam String code, HttpServletResponse response) {
-        return authService.login(code, SocialType.NAVER, response);
-    }
+
 
     @PostMapping("/login/naver/app")
     @Operation(summary = "앱용 네이버 로그인 API", description = "네이버 인가코드를 받고 JWT 토큰을 리턴합니다.")
@@ -62,11 +60,6 @@ public class AuthController {
         return authService.loginForApp(accessToken, SocialType.NAVER, response);
     }
 
-    @PostMapping("login/google")
-    @Operation(summary = "구글 로그인 API", description = "구글 인가코드를 받고 JWT 토큰을 리턴합니다.")
-    ApiResponse<LoginResponse> loginGoogle(@RequestParam String code, HttpServletResponse response) {
-        return authService.login(code, SocialType.GOOGLE, response);
-    }
 
     @GetMapping("/test")
     @Operation(summary = "로그인 테스트 API", description = "로그인 여부를 확인할 수 있는 API입니다. 회원의 닉네임을 리턴합니다.")

--- a/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
+++ b/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
@@ -32,7 +32,6 @@ public class AuthController {
     /**
      * 로그인
      */
-
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "테스트용 기본 로그인 API입니다.")
     public ApiResponse<LoginResponse> login(@RequestParam String code, HttpServletResponse response) {
@@ -46,20 +45,11 @@ public class AuthController {
         return authService.login(code, socialType.toUpperCase(), response);
     }
 
-    @PostMapping("/login/kakao/app")
-    @Operation(summary = "앱용 카카오 로그인 API", description = "카카오 서버에 접근할 수 있는 accessToken을 받고 JWT 토큰을 리턴합니다.")
-    ApiResponse<LoginResponse> loginKakaoForApp(@RequestParam String accessToken, HttpServletResponse response) {
-        return authService.loginForApp(accessToken, SocialType.KAKAO, response);
+    @PostMapping("/login/{socialType}/app")
+    @Operation(summary = "앱용 소셜 로그인 API", description = "소셜 로그인 서버에 접근할 수 있는 accessToken을 받고 JWT 토큰을 리턴합니다. socialType -> {KAKAO, NAVER, GOOGLE}")
+    ApiResponse<LoginResponse> loginKakaoForApp(@RequestParam String accessToken, @PathVariable String socialType, HttpServletResponse response) {
+        return authService.loginForApp(accessToken, socialType, response);
     }
-
-
-
-    @PostMapping("/login/naver/app")
-    @Operation(summary = "앱용 네이버 로그인 API", description = "네이버 인가코드를 받고 JWT 토큰을 리턴합니다.")
-    ApiResponse<LoginResponse> loginNaverForApp(@RequestParam String accessToken, HttpServletResponse response) {
-        return authService.loginForApp(accessToken, SocialType.NAVER, response);
-    }
-
 
     @GetMapping("/test")
     @Operation(summary = "로그인 테스트 API", description = "로그인 여부를 확인할 수 있는 API입니다. 회원의 닉네임을 리턴합니다.")
@@ -70,6 +60,9 @@ public class AuthController {
         return new ApiResponse<>(result);
     }
 
+    /**
+     * 회원가입
+     */
     @PostMapping("/signup")
     @Operation(summary = "회원가입 API", description = "회원가입을 진행하는 API입니다. (SocialType : BASIC, GOOGLE, NAVER, KAKAO")
     public ApiResponse<Void> signUp(@RequestBody @Valid SignUpRequest signUpRequest, HttpServletResponse response) {

--- a/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
+++ b/src/main/java/com/adoonge/seedzip/auth/controller/AuthController.java
@@ -62,6 +62,12 @@ public class AuthController {
         return authService.loginForApp(accessToken, SocialType.NAVER, response);
     }
 
+    @PostMapping("login/google")
+    @Operation(summary = "구글 로그인 API", description = "구글 인가코드를 받고 JWT 토큰을 리턴합니다.")
+    ApiResponse<LoginResponse> loginGoogle(@RequestParam String code, HttpServletResponse response) {
+        return authService.login(code, SocialType.GOOGLE, response);
+    }
+
     @GetMapping("/test")
     @Operation(summary = "로그인 테스트 API", description = "로그인 여부를 확인할 수 있는 API입니다. 회원의 닉네임을 리턴합니다.")
     public ApiResponse<String> test(@AuthenticationPrincipal CustomUserDetails customUserDetails) {

--- a/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
+++ b/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
@@ -37,7 +37,13 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public ApiResponse<LoginResponse> login(String code, SocialType socialType, HttpServletResponse response) {
+    public ApiResponse<LoginResponse> login(String code, String input, HttpServletResponse response) {
+        SocialType socialType;
+        try{
+            socialType = SocialType.valueOf(input);
+        } catch (IllegalStateException e) {
+            throw SeedzipException.from(ErrorCode.INVALID_SOCIAL_CODE);
+        }
 
         OAuthService oauthService = oauthServiceFactory.getOAuthService(socialType);
 

--- a/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
+++ b/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
@@ -41,7 +41,7 @@ public class AuthService {
 
         OAuthService oauthService = oauthServiceFactory.getOAuthService(socialType);
 
-        String accessToken = oauthService.getAccessToken(code);
+        String accessToken = oauthService.getSocialAccessToken(code);
 
         String loginId = oauthService.getLoginId(accessToken);
 

--- a/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
+++ b/src/main/java/com/adoonge/seedzip/auth/service/AuthService.java
@@ -30,7 +30,6 @@ public class AuthService {
     private final JwtTokenService jwtTokenService;
     private final OAuthServiceFactory oauthServiceFactory;
     private final PasswordEncoder passwordEncoder;
-    private final CategoryRepository categoryRepository;
 
     private Boolean isMemberRegistered(String loginId) {
         return memberRepository.existsByLoginId(loginId);
@@ -61,7 +60,13 @@ public class AuthService {
     }
 
     @Transactional(readOnly = true)
-    public ApiResponse<LoginResponse> loginForApp(String accessToken, SocialType socialType,HttpServletResponse response) {
+    public ApiResponse<LoginResponse> loginForApp(String accessToken, String input, HttpServletResponse response) {
+        SocialType socialType;
+        try{
+            socialType = SocialType.valueOf(input);
+        } catch (IllegalStateException e) {
+            throw SeedzipException.from(ErrorCode.INVALID_SOCIAL_CODE);
+        }
 
         OAuthService oauthService = oauthServiceFactory.getOAuthService(socialType);
 

--- a/src/main/java/com/adoonge/seedzip/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/adoonge/seedzip/global/config/RestTemplateConfig.java
@@ -1,0 +1,21 @@
+package com.adoonge.seedzip.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(5000);
+        requestFactory.setReadTimeout(5000);
+
+        restTemplate.setRequestFactory(requestFactory);
+
+        return restTemplate;
+    }
+}

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
     OAUTH2_INVALID_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 OAuth2 에러가 발생했습니다."),
     OPEN_ID_PROVIDER_NOT_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "OpenID 제공자 서버에 문제가 발생했습니다."),
     OAUTH2_INVALID_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 인가 코드입니다."),
+    INVALID_SOCIAL_CODE(HttpStatus.BAD_REQUEST, "잘못된 소셜코드입니다."),
 
     // file
     EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -31,6 +31,7 @@ public enum ErrorCode {
     OAUTH2_PROVIDER_NOT_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "OAuth2 제공자 서버에 문제가 발생했습니다."),
     OAUTH2_INVALID_REQUEST(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 OAuth2 에러가 발생했습니다."),
     OPEN_ID_PROVIDER_NOT_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "OpenID 제공자 서버에 문제가 발생했습니다."),
+    OAUTH2_INVALID_CODE(HttpStatus.BAD_REQUEST, "올바르지 않은 인가 코드입니다."),
 
     // file
     EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),

--- a/src/main/java/com/adoonge/seedzip/oauth/service/BasicService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/BasicService.java
@@ -1,14 +1,27 @@
 package com.adoonge.seedzip.oauth.service;
 
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class BasicService implements OAuthService{
 
+
     @Override
-    public String getAccessToken(String code) {
+    public ResponseEntity<Map> requestSocialUserAccessToken(String code) {
+        return null;
+    }
+
+    @Override
+    public ResponseEntity<Map> requestSocialUserInfo(String socialAccessToken) {
+        return null;
+    }
+
+    @Override
+    public String getSocialAccessToken(String code) {
         return code;
     }
 

--- a/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
@@ -2,12 +2,9 @@ package com.adoonge.seedzip.oauth.service;
 
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -18,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class GoogleService implements OAuthService{

--- a/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
@@ -1,13 +1,18 @@
 package com.adoonge.seedzip.oauth.service;
 
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -27,56 +32,77 @@ public class GoogleService implements OAuthService{
     @Value("${GOOGLE_REDIRECT_URI}")
     private String googleRedirectUri;
 
+    @Autowired
+    RestTemplate restTemplate;
+
     @Override
-    public String getAccessToken(String code) {
-        String reqUrl = "https://oauth2.googleapis.com/token";
-        RestTemplate restTemplate = new RestTemplate();
-
-        // HttpHeader Object
+    public ResponseEntity<Map> requestSocialUserAccessToken(String code) {
+        // 요청 헤더 설정
         HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        // HttpBody Object
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", googleClientId);
-        params.add("client_secret", googleClientSecret);
-        params.add("redirect_uri", googleRedirectUri);
-        params.add("code", code);
+        // 요청 바디 설정
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", googleClientId);
+        body.add("client_secret", googleClientSecret);
+        body.add("redirect_uri", googleRedirectUri);
+        body.add("code", code);
 
-        // http 바디 params 와 http 헤더 headers 를 가진 엔티티
-        HttpEntity<MultiValueMap<String, String>> googleTokenRequest = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
-        // reqUrl 로 Http 요청, POST 방식
-        ResponseEntity<String> response = restTemplate.exchange(reqUrl,
-                HttpMethod.POST,
-                googleTokenRequest,
-                String.class);
+        // POST 요청 실행
+        String requestUrl = "https://oauth2.googleapis.com/token";
+        return restTemplate.exchange(requestUrl, HttpMethod.POST, request, Map.class);    }
 
-        String responseBody = response.getBody();
-        JsonObject asJsonObject = JsonParser.parseString(responseBody).getAsJsonObject();
+    @Override
+    public ResponseEntity<Map> requestSocialUserInfo(String socialAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + socialAccessToken);
+        headers.set("Content-Type", "application/json");
 
-        return asJsonObject.get("access_token").getAsString();
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        String requestUrl = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+        return restTemplate.exchange(requestUrl, HttpMethod.GET, request, Map.class);    }
+
+    @Override
+    public String getSocialAccessToken(String socialCode) {
+        ResponseEntity<Map> response = requestSocialUserAccessToken(socialCode);
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Map<String, Object> responseBody = response.getBody();
+            return responseBody != null ? (String) responseBody.get("access_token") : null;
+        } else {
+            throw SeedzipException.from(ErrorCode.OAUTH2_INVALID_CODE);
+        }
     }
 
     @Override
     public String getLoginId(String accessToken) {
-        return getUserAttributesByToken(accessToken).get("sub").toString();
+        // 1. Google API로 사용자 정보 요청
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Failed to fetch user info from Google API.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+
+        return responseBody.get("sub").toString();
     }
 
     @Override
     public String getProfileImageUrl(String accessToken) {
-        String imageUrl = getUserAttributesByToken(accessToken).get("sub").toString();
-        return imageUrl != null ? imageUrl : ""; // 추후에 기본 이미지 링크 추가
+        // 1. Google API로 사용자 정보 요청
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Failed to fetch user info from Google API.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+
+        return responseBody.get("picture").toString();
     }
 
-    private Map<String, Object> getUserAttributesByToken(String accessToken){
-        return WebClient.create()
-                .get()
-                .uri("https://www.googleapis.com/oauth2/v3/userinfo")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .block();
-    }
 }

--- a/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/GoogleService.java
@@ -1,0 +1,82 @@
+package com.adoonge.seedzip.oauth.service;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Service
+public class GoogleService implements OAuthService{
+
+    @Value("${GOOGLE_CLIENT_ID}")
+    private String googleClientId;
+
+    @Value("${GOOGLE_CLIENT_SECRET}")
+    private String googleClientSecret;
+
+    @Value("${GOOGLE_REDIRECT_URI}")
+    private String googleRedirectUri;
+
+    @Override
+    public String getAccessToken(String code) {
+        String reqUrl = "https://oauth2.googleapis.com/token";
+        RestTemplate restTemplate = new RestTemplate();
+
+        // HttpHeader Object
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // HttpBody Object
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", googleClientId);
+        params.add("client_secret", googleClientSecret);
+        params.add("redirect_uri", googleRedirectUri);
+        params.add("code", code);
+
+        // http 바디 params 와 http 헤더 headers 를 가진 엔티티
+        HttpEntity<MultiValueMap<String, String>> googleTokenRequest = new HttpEntity<>(params, headers);
+
+        // reqUrl 로 Http 요청, POST 방식
+        ResponseEntity<String> response = restTemplate.exchange(reqUrl,
+                HttpMethod.POST,
+                googleTokenRequest,
+                String.class);
+
+        String responseBody = response.getBody();
+        JsonObject asJsonObject = JsonParser.parseString(responseBody).getAsJsonObject();
+
+        return asJsonObject.get("access_token").getAsString();
+    }
+
+    @Override
+    public String getLoginId(String accessToken) {
+        return getUserAttributesByToken(accessToken).get("sub").toString();
+    }
+
+    @Override
+    public String getProfileImageUrl(String accessToken) {
+        String imageUrl = getUserAttributesByToken(accessToken).get("sub").toString();
+        return imageUrl != null ? imageUrl : ""; // 추후에 기본 이미지 링크 추가
+    }
+
+    private Map<String, Object> getUserAttributesByToken(String accessToken){
+        return WebClient.create()
+                .get()
+                .uri("https://www.googleapis.com/oauth2/v3/userinfo")
+                .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+    }
+}

--- a/src/main/java/com/adoonge/seedzip/oauth/service/KakaoService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/KakaoService.java
@@ -1,19 +1,20 @@
 package com.adoonge.seedzip.oauth.service;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class KakaoService implements OAuthService {
@@ -22,15 +23,82 @@ public class KakaoService implements OAuthService {
     private String kakaoApiKey;
     @Value("${KAKAO_REDIRECT_URI}")
     private String kakaoRedirectUri;
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Override
+    public ResponseEntity<Map> requestSocialUserAccessToken(String code) {
+        // 요청 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        // 요청 바디 설정
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", kakaoApiKey);
+        body.add("redirect_uri", kakaoRedirectUri);
+        body.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
+
+        // POST 요청 실행
+        String requestUrl = "https://kauth.kakao.com/oauth/token";
+        try {
+            return restTemplate.exchange(requestUrl, HttpMethod.POST, request, Map.class);
+        } catch (Exception e) {
+            throw SeedzipException.from(ErrorCode.OAUTH2_INVALID_CODE);
+        }
+    }
+
+    @Override
+    public ResponseEntity<Map> requestSocialUserInfo(String socialAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + socialAccessToken);
+        headers.set("Content-Type", "application/x-www-form-urlencoded");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        String requestUrl = "https://kapi.kakao.com/v2/user/me";
+
+        return restTemplate.exchange(requestUrl, HttpMethod.GET, request, Map.class);
+    }
+
+    @Override
+    public String getSocialAccessToken(String code) {
+        ResponseEntity<Map> response = requestSocialUserAccessToken(code);
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Map<String, Object> responseBody = response.getBody();
+            return responseBody != null ? (String) responseBody.get("access_token") : null;
+        } else {
+            throw SeedzipException.from(ErrorCode.OAUTH2_INVALID_CODE);
+        }
+    }
 
     @Override
     public String getLoginId(String accessToken) {
-        return getUserAttributesByToken(accessToken).get("id").toString();
+        // 1. 카카오 API로 사용자 정보 요청
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Failed to fetch user info from Kakao API.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+
+        return responseBody.get("id").toString();
     }
 
     @Override
     public String getProfileImageUrl(String accessToken) {
-        Map<String, Object> kakaoAccount = (Map<String, Object>) getUserAttributesByToken(accessToken).get("kakao_account");
+        // 1. 카카오 API로 사용자 정보 요청
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Failed to fetch user info from Kakao API.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) responseBody.get("kakao_account");
         if(kakaoAccount != null) {
             Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
             if(profile != null) {
@@ -40,47 +108,5 @@ public class KakaoService implements OAuthService {
             }
         }
         return null; //추후에 기본 프로필 이미지 링크 추가
-    }
-
-    @Override
-    public String getAccessToken(String code) {
-
-        String reqUrl = "https://kauth.kakao.com/oauth/token";
-        RestTemplate restTemplate = new RestTemplate();
-
-        // HttpHeader Object
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
-
-        // HttpBody Object
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", kakaoApiKey);
-        params.add("redirect_uri", kakaoRedirectUri);
-        params.add("code", code);
-
-        // http 바디 params 와 http 헤더 headers 를 가진 엔티티
-        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
-
-        // reqUrl 로 Http 요청, POST 방식
-        ResponseEntity<String> response = restTemplate.exchange(reqUrl,
-                HttpMethod.POST,
-                kakaoTokenRequest,
-                String.class);
-
-        String responseBody = response.getBody();
-        JsonObject asJsonObject = JsonParser.parseString(responseBody).getAsJsonObject();
-
-        return asJsonObject.get("access_token").getAsString();
-    }
-
-    private Map<String, Object> getUserAttributesByToken(String accessToken){
-        return WebClient.create()
-                .get()
-                .uri("https://kapi.kakao.com/v2/user/me")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .block();
     }
 }

--- a/src/main/java/com/adoonge/seedzip/oauth/service/NaverService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/NaverService.java
@@ -1,13 +1,18 @@
 package com.adoonge.seedzip.oauth.service;
 
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
@@ -19,66 +24,95 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class NaverService implements OAuthService{
 
     @Value("${NAVER_CLIENT_ID}")
-    private String clientId;
+    private String naverClientId;
 
     @Value("${NAVER_CLIENT_SECRET}")
-    private String clientSecret;
+    private String naverClientSecret;
 
     @Value("${NAVER_REDIRECT_URI}")
-    private String redirectUri;
+    private String naverRedirectUri;
+
+    @Autowired
+    RestTemplate restTemplate;
 
     @Override
-    public String getAccessToken(String code) {
-        String reqUrl = "https://nid.naver.com/oauth2.0/token";
-        RestTemplate restTemplate = new RestTemplate();
+    public ResponseEntity<Map> requestSocialUserAccessToken(String code) {
+        String requestUrl = "https://nid.naver.com/oauth2.0/token";
 
-        // HttpHeader Object
         HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        // HttpBody Object
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", clientId);
-        params.add("client_secret", clientSecret);
-        params.add("code", code);
-        params.add("state", "seedzip");
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("client_id", naverClientId);
+        body.add("client_secret", naverClientSecret);
+        body.add("redirect_uri", naverRedirectUri);
+        body.add("state", "seedzip");
+        body.add("code", code);
 
-        // http body params 와 http headers 를 가진 엔티티
-        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(params, headers);
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(body, headers);
 
-        // reqUrl로 Http 요청, POST 방식
-        ResponseEntity<String> response = restTemplate.exchange(reqUrl,
-                HttpMethod.POST,
-                naverTokenRequest,
-                String.class);
+        return restTemplate.exchange(requestUrl, HttpMethod.POST, request, Map.class);
+    }
 
-        String responseBody = response.getBody();
-        JsonObject asJsonObject = JsonParser.parseString(responseBody).getAsJsonObject();
-        return asJsonObject.get("access_token").getAsString();
+    @Override
+    public ResponseEntity<Map> requestSocialUserInfo(String socialAccessToken) {
+        String requestUrl = "https://openapi.naver.com/v1/nid/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + socialAccessToken);
+        headers.set("Content-Type", "application/x-www-form-urlencoded");
+
+        HttpEntity<String> request = new HttpEntity<>(headers);
+        return restTemplate.exchange(requestUrl, HttpMethod.GET, request, Map.class);    }
+
+    @Override
+    public String getSocialAccessToken(String socialCode) {
+        ResponseEntity<Map> response = requestSocialUserAccessToken(socialCode);
+        if (response.getStatusCode() == HttpStatus.OK) {
+            Map<String, Object> responseBody = response.getBody();
+            return responseBody != null ? (String) responseBody.get("access_token") : null;
+        } else {
+            throw SeedzipException.from(ErrorCode.OAUTH2_INVALID_CODE);
+        }
     }
 
     @Override
     public String getLoginId(String accessToken) {
-        Map<String, Object> naverAccount = (Map<String, Object>) getUserAttributesByToken(accessToken).get("response");
-        return naverAccount.get("id").toString();
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Naver API에서 사용자 정보를 가져오지 못했습니다.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+        if (!responseBody.containsKey("response")) {
+            throw new RuntimeException("Naver API 응답에 사용자 정보가 없습니다.");
+        }
+
+        Map<String, Object> userInfo = (Map<String, Object>) responseBody.get("response");
+
+        return userInfo.get("id").toString();
     }
 
     @Override
     public String getProfileImageUrl(String accessToken) {
-        Map<String, Object> naverAccount = (Map<String, Object>) getUserAttributesByToken(accessToken).get("response");
-        if(naverAccount != null){
-            return naverAccount.get("profile_image").toString();
+        ResponseEntity<Map> response = requestSocialUserInfo(accessToken);
+
+        if (response.getStatusCode() != HttpStatus.OK || response.getBody() == null) {
+            throw new RuntimeException("Naver API에서 사용자 정보를 가져오지 못했습니다.");
+        }
+
+        Map<String, Object> responseBody = response.getBody();
+        if (!responseBody.containsKey("response")) {
+            throw new RuntimeException("Naver API 응답에 사용자 정보가 없습니다.");
+        }
+
+        Map<String, Object> userInfo = (Map<String, Object>) responseBody.get("response");
+        if(userInfo != null){
+            return userInfo.get("profile_image").toString();
         }
         return null; // 추후에 기본 프로필 이미지 링크 추가
     }
 
-    private Map<String, Object> getUserAttributesByToken(String accessToken){
-        return WebClient.create()
-                .get()
-                .uri("https://openapi.naver.com/v1/nid/me")
-                .headers(httpHeaders -> httpHeaders.setBearerAuth(accessToken))
-                .retrieve()
-                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
-                .block();
-    }
 }

--- a/src/main/java/com/adoonge/seedzip/oauth/service/NaverService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/NaverService.java
@@ -2,12 +2,9 @@ package com.adoonge.seedzip.oauth.service;
 
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -18,7 +15,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.reactive.function.client.WebClient;
 
 @Service
 public class NaverService implements OAuthService{

--- a/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 public interface OAuthService {
     ResponseEntity<Map> requestSocialUserAccessToken(String code);
     ResponseEntity<Map> requestSocialUserAccessInfo(String socialAccessToken);
-    String getAccessToken(String socialCode); //state는 네이버 로그인시만 필요
+    String getSocialAccessToken(String socialCode); //state는 네이버 로그인시만 필요
     String getLoginId(String socialAccessToken);
     String getProfileImageUrl(String socialAccessToken);
 }

--- a/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
@@ -1,9 +1,13 @@
 package com.adoonge.seedzip.oauth.service;
 
+import java.util.Map;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface OAuthService {
+    ResponseEntity<Map> requestSocialUserAccessToken(String code);
+    ResponseEntity<Map> requestSocialUserAccessInfo(String socialAccessToken);
     String getAccessToken(String socialCode); //state는 네이버 로그인시만 필요
     String getLoginId(String socialAccessToken);
     String getProfileImageUrl(String socialAccessToken);

--- a/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/OAuthService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 @Service
 public interface OAuthService {
     ResponseEntity<Map> requestSocialUserAccessToken(String code);
-    ResponseEntity<Map> requestSocialUserAccessInfo(String socialAccessToken);
+    ResponseEntity<Map> requestSocialUserInfo(String socialAccessToken);
     String getSocialAccessToken(String socialCode); //state는 네이버 로그인시만 필요
     String getLoginId(String socialAccessToken);
     String getProfileImageUrl(String socialAccessToken);

--- a/src/main/java/com/adoonge/seedzip/oauth/service/OAuthServiceFactory.java
+++ b/src/main/java/com/adoonge/seedzip/oauth/service/OAuthServiceFactory.java
@@ -26,6 +26,9 @@ public class OAuthServiceFactory {
         else if(service instanceof NaverService) {
             return SocialType.NAVER;
         }
+        else if(service instanceof GoogleService) {
+            return SocialType.GOOGLE;
+        }
         else if (service instanceof BasicService) {
             return SocialType.BASIC;
         }


### PR DESCRIPTION
## 🪺 Summary
구글 로그인 구현했고, 소셜 로그인 서버에 요청할 때,  RestTemplate과 WebClient가 섞여 있었는데, 일단은 RestTemplate으로 리팩토링해놨습니다. 추후에 WebClient 공부해서 바꾸면 좋을 거 같아요!

팩토리 패턴을 이용하여 소셜 로그인 엔드포인트 하나로 통합했습니다.
<img width="1438" alt="image" src="https://github.com/user-attachments/assets/e056624c-c1ae-4a11-ac24-49cd207028c3" />

```java
@Service // 팩토리 패턴 사용해서 SocialType에 맞는 serivce 리턴
public class OAuthServiceFactory {

    private final Map<SocialType, OAuthService> oauthServices;

    public OAuthServiceFactory(List<OAuthService> oauthServiceList) {
        this.oauthServices = oauthServiceList.stream()
                .collect(Collectors.toMap(
                        service -> getSocialType(service),
                        service -> service
                ));
    }

    private SocialType getSocialType(OAuthService service) {
        if (service instanceof KakaoService) {
            return SocialType.KAKAO;
        }
        else if(service instanceof NaverService) {
            return SocialType.NAVER;
        }
        else if(service instanceof GoogleService) {
            return SocialType.GOOGLE;
        }
        else if (service instanceof BasicService) {
            return SocialType.BASIC;
        }
        throw new IllegalArgumentException("Unknown OAuthService type: " + service.getClass());
    }

    public OAuthService getOAuthService(SocialType socialType) {
        return oauthServices.get(socialType);
    }
}
```

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #118


## 🙏 To Reviewers
