### PR TITLE
Refactor : AI 요약 기능에 횟수 제한을 추가한다

### DIFF
--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -106,7 +106,10 @@ public enum ErrorCode {
     FILTER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "이 필터에 대한 접근 권한이 없습니다."),
 
     // recommendation
-    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다.");
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "유효하지 않은 입력 값입니다."),
+
+    // AI
+    DAILY_AI_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "AI 분석 요청 횟수를 초과했습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
+++ b/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
@@ -32,7 +32,7 @@ public class MemberAiUsages extends BaseEntity {
 
 	@OneToOne
 	@JoinColumn(name = "member_id")
-	private Member memberId;
+	private Member member;
 
 	private LocalDate lastUsedDate;
 

--- a/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
+++ b/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
@@ -1,0 +1,40 @@
+package com.adoonge.seedzip.member.domain;
+
+import java.time.LocalDate;
+
+import com.adoonge.seedzip.global.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@Entity
+@Table(name = "member_ai_usages")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberAiUsages extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne
+	@JoinColumn(name = "member_id")
+	private Member memberId;
+
+	private LocalDate lastUsedDate;
+
+	private Long usageCount;
+}

--- a/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
+++ b/src/main/java/com/adoonge/seedzip/member/domain/MemberAiUsages.java
@@ -36,5 +36,9 @@ public class MemberAiUsages extends BaseEntity {
 
 	private LocalDate lastUsedDate;
 
-	private Long usageCount;
+	private Long usageCount = 0L;
+
+	public void increaseUsageCount() {
+		this.usageCount++;
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
+++ b/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
@@ -1,5 +1,7 @@
 package com.adoonge.seedzip.member.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -7,4 +9,6 @@ import com.adoonge.seedzip.member.domain.MemberAiUsages;
 
 @Repository
 public interface MemberAiUsageRepository extends JpaRepository<MemberAiUsages, Long> {
+
+	Optional<MemberAiUsages> findByMemberId(Long memberId);
 }

--- a/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
+++ b/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
@@ -1,14 +1,18 @@
 package com.adoonge.seedzip.member.repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.member.domain.MemberAiUsages;
 
 @Repository
 public interface MemberAiUsageRepository extends JpaRepository<MemberAiUsages, Long> {
 
 	Optional<MemberAiUsages> findByMemberId(Long memberId);
+
+	void deleteByLastUsedDateBefore(LocalDate lastUsedDateBefore);
 }

--- a/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
+++ b/src/main/java/com/adoonge/seedzip/member/repository/MemberAiUsageRepository.java
@@ -1,0 +1,10 @@
+package com.adoonge.seedzip.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.adoonge.seedzip.member.domain.MemberAiUsages;
+
+@Repository
+public interface MemberAiUsageRepository extends JpaRepository<MemberAiUsages, Long> {
+}

--- a/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationController.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationController.java
@@ -57,38 +57,4 @@ public class SimplificationController {
         return new ApiResponse<>(simplificationResponse);
     }
 
-    /**
-     * s3 먼저 저장하는 버전
-     */
-    @PostMapping(value = "/image/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "이미지 간략화 관련 API(v2)", description = "이미지를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-    public ApiResponse<SimplificationAllResponse.simplificationFileResponse> imageAnalysisV2(@Parameter(description = "업로드할 이미지", content = @Content(mediaType = "application/octet-stream"))
-                                                                 @RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) {
-        SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestImageAnalysisV2(files, thumbnailIdx);
-        return new ApiResponse<>(response);
-    }
-
-    @PostMapping("/youtube/v2")
-    @Operation(summary = "유튜브 간략화 관련 API(v2)", description = "유튜브 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-    public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> youtubeAnalysisV2(@RequestParam String youtubeUrl) throws IOException {
-        String youtubeData = youTubeService.searchVideos(youtubeUrl);   // 유튜브 데이터 조회
-        SimplificationAllResponse.simplificationLinkResponse response = simplificationService.requestTextAnalysisV2(youtubeData); // 요약 데이터 조회
-        response.setLink(youtubeUrl);
-        return new ApiResponse<>(response);
-    }
-
-    @PostMapping(value = "/pdf/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "PDF 간략화 관련 API(v2)", description = "PDF 파일을 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-    public ApiResponse<SimplificationAllResponse.simplificationFileResponse> pdfAnalysisV2(@Parameter(description = "업로드할 pdf", content = @Content(mediaType = "application/octet-stream"))
-                                                               @RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) throws IOException {
-        SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestPdfAnalysisV2(files, thumbnailIdx);
-        return new ApiResponse<>(response);
-    }
-
-    @PostMapping(value = "/naver-news/v2")
-    @Operation(summary = "네이버 뉴스 간략화 관련 API(v2)", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-    public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> naverNewsAnalysisV2(@RequestParam String naverNewsUrl) throws IOException {
-        SimplificationAllResponse.simplificationLinkResponse simplificationInfoResponse = simplificationService.requestNaverNewsAnalysisV2(naverNewsUrl);
-        return new ApiResponse<>(simplificationInfoResponse);
-    }
 }

--- a/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationController.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationController.java
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1/simplification")
 @RequiredArgsConstructor
-@Tag(name = "SimplificationController", description = "제목, 요약, 태그 간략화 관련 API")
+@Tag(name = "SimplificationController V1", description = "제목, 요약, 태그 간략화 관련 API V1")
 public class SimplificationController {
 
     private final SimplificationService simplificationService;

--- a/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
@@ -4,12 +4,14 @@ import java.io.IOException;
 import java.util.List;
 
 import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.adoonge.seedzip.auth.util.CustomUserDetails;
 import com.adoonge.seedzip.global.dto.response.ApiResponse;
 import com.adoonge.seedzip.simplification.dto.response.SimplificationAllResponse;
 import com.adoonge.seedzip.simplification.service.SimplificationService;
@@ -37,15 +39,20 @@ public class SimplificationControllerV2 {
 	@PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "이미지 간략화 관련 API(v2)", description = "이미지를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> imageAnalysisV2(@Parameter(description = "업로드할 이미지", content = @Content(mediaType = "application/octet-stream"))
-	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) {
+		@RequestParam(value = "files", required = false) List<MultipartFile> files,
+		@RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		simplificationService.checkDailyAiUsage(customUserDetails.getMember());
 		SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestImageAnalysisV2(files, thumbnailIdx);
 		return new ApiResponse<>(response);
 	}
 
 	@PostMapping("/youtube")
 	@Operation(summary = "유튜브 간략화 관련 API(v2)", description = "유튜브 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> youtubeAnalysisV2(@RequestParam String youtubeUrl) throws
+	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> youtubeAnalysisV2(@RequestParam String youtubeUrl,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) throws
 		IOException {
+		simplificationService.checkDailyAiUsage(customUserDetails.getMember());
 		String youtubeData = youTubeService.searchVideos(youtubeUrl);   // 유튜브 데이터 조회
 		SimplificationAllResponse.simplificationLinkResponse response = simplificationService.requestTextAnalysisV2(youtubeData); // 요약 데이터 조회
 		response.setLink(youtubeUrl);
@@ -55,14 +62,18 @@ public class SimplificationControllerV2 {
 	@PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "PDF 간략화 관련 API(v2)", description = "PDF 파일을 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> pdfAnalysisV2(@Parameter(description = "업로드할 pdf", content = @Content(mediaType = "application/octet-stream"))
-	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) throws IOException {
+		@RequestParam(value = "files", required = false) List<MultipartFile> files,
+		@RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx,
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
+		simplificationService.checkDailyAiUsage(customUserDetails.getMember());
 		SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestPdfAnalysisV2(files, thumbnailIdx);
 		return new ApiResponse<>(response);
 	}
 
 	@PostMapping(value = "/naver-news")
 	@Operation(summary = "네이버 뉴스 간략화 관련 API(v2)", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
-	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> naverNewsAnalysisV2(@RequestParam String naverNewsUrl) throws IOException {
+	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> naverNewsAnalysisV2(@RequestParam String naverNewsUrl, @AuthenticationPrincipal CustomUserDetails customUserDetails) throws IOException {
+		simplificationService.checkDailyAiUsage(customUserDetails.getMember());
 		SimplificationAllResponse.simplificationLinkResponse simplificationInfoResponse = simplificationService.requestNaverNewsAnalysisV2(naverNewsUrl);
 		return new ApiResponse<>(simplificationInfoResponse);
 	}

--- a/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
@@ -1,0 +1,69 @@
+package com.adoonge.seedzip.simplification.controller;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.adoonge.seedzip.global.dto.response.ApiResponse;
+import com.adoonge.seedzip.simplification.dto.response.SimplificationAllResponse;
+import com.adoonge.seedzip.simplification.service.SimplificationService;
+import com.adoonge.seedzip.simplification.service.YouTubeService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v2/simplification")
+@RequiredArgsConstructor
+@Tag(name = "SimplificationController V2", description = "제목, 요약, 태그 간략화 관련 API V2")
+public class SimplificationControllerV2 {
+
+	private final SimplificationService simplificationService;
+
+	private final YouTubeService youTubeService;
+
+	/**
+	 * s3 먼저 저장하는 버전
+	 */
+	@PostMapping(value = "/image/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "이미지 간략화 관련 API(v2)", description = "이미지를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
+	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> imageAnalysisV2(@Parameter(description = "업로드할 이미지", content = @Content(mediaType = "application/octet-stream"))
+	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) {
+		SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestImageAnalysisV2(files, thumbnailIdx);
+		return new ApiResponse<>(response);
+	}
+
+	@PostMapping("/youtube/v2")
+	@Operation(summary = "유튜브 간략화 관련 API(v2)", description = "유튜브 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
+	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> youtubeAnalysisV2(@RequestParam String youtubeUrl) throws
+		IOException {
+		String youtubeData = youTubeService.searchVideos(youtubeUrl);   // 유튜브 데이터 조회
+		SimplificationAllResponse.simplificationLinkResponse response = simplificationService.requestTextAnalysisV2(youtubeData); // 요약 데이터 조회
+		response.setLink(youtubeUrl);
+		return new ApiResponse<>(response);
+	}
+
+	@PostMapping(value = "/pdf/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@Operation(summary = "PDF 간략화 관련 API(v2)", description = "PDF 파일을 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
+	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> pdfAnalysisV2(@Parameter(description = "업로드할 pdf", content = @Content(mediaType = "application/octet-stream"))
+	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) throws IOException {
+		SimplificationAllResponse.simplificationFileResponse response = simplificationService.requestPdfAnalysisV2(files, thumbnailIdx);
+		return new ApiResponse<>(response);
+	}
+
+	@PostMapping(value = "/naver-news/v2")
+	@Operation(summary = "네이버 뉴스 간략화 관련 API(v2)", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
+	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> naverNewsAnalysisV2(@RequestParam String naverNewsUrl) throws IOException {
+		SimplificationAllResponse.simplificationLinkResponse simplificationInfoResponse = simplificationService.requestNaverNewsAnalysisV2(naverNewsUrl);
+		return new ApiResponse<>(simplificationInfoResponse);
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/controller/SimplificationControllerV2.java
@@ -34,7 +34,7 @@ public class SimplificationControllerV2 {
 	/**
 	 * s3 먼저 저장하는 버전
 	 */
-	@PostMapping(value = "/image/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(value = "/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "이미지 간략화 관련 API(v2)", description = "이미지를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> imageAnalysisV2(@Parameter(description = "업로드할 이미지", content = @Content(mediaType = "application/octet-stream"))
 	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) {
@@ -42,7 +42,7 @@ public class SimplificationControllerV2 {
 		return new ApiResponse<>(response);
 	}
 
-	@PostMapping("/youtube/v2")
+	@PostMapping("/youtube")
 	@Operation(summary = "유튜브 간략화 관련 API(v2)", description = "유튜브 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> youtubeAnalysisV2(@RequestParam String youtubeUrl) throws
 		IOException {
@@ -52,7 +52,7 @@ public class SimplificationControllerV2 {
 		return new ApiResponse<>(response);
 	}
 
-	@PostMapping(value = "/pdf/v2", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	@PostMapping(value = "/pdf", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@Operation(summary = "PDF 간략화 관련 API(v2)", description = "PDF 파일을 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationFileResponse> pdfAnalysisV2(@Parameter(description = "업로드할 pdf", content = @Content(mediaType = "application/octet-stream"))
 	@RequestParam(value = "files", required = false) List<MultipartFile> files, @RequestParam(value = "thumbnailIdx", required = false) int thumbnailIdx) throws IOException {
@@ -60,7 +60,7 @@ public class SimplificationControllerV2 {
 		return new ApiResponse<>(response);
 	}
 
-	@PostMapping(value = "/naver-news/v2")
+	@PostMapping(value = "/naver-news")
 	@Operation(summary = "네이버 뉴스 간략화 관련 API(v2)", description = "네이버 뉴스 링크를 넣으면 제목, 요약, 태그를 간략화해주는 API입니다.")
 	public ApiResponse<SimplificationAllResponse.simplificationLinkResponse> naverNewsAnalysisV2(@RequestParam String naverNewsUrl) throws IOException {
 		SimplificationAllResponse.simplificationLinkResponse simplificationInfoResponse = simplificationService.requestNaverNewsAnalysisV2(naverNewsUrl);

--- a/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
@@ -51,7 +51,7 @@ public class SimplificationService {
     private final MemberAiUsageRepository memberAiUsageRepository;
     private final MemberRepository memberRepository;
 
-    private final static int DAILY_AI_LIMIT = 5;
+    private final static int DAILY_AI_LIMIT = 10;
 
     /**
      * 기존 버전

--- a/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
@@ -3,6 +3,10 @@ package com.adoonge.seedzip.simplification.service;
 import com.adoonge.seedzip.content.service.S3Service;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.member.domain.MemberAiUsages;
+import com.adoonge.seedzip.member.repository.MemberAiUsageRepository;
+import com.adoonge.seedzip.member.repository.MemberRepository;
 import com.adoonge.seedzip.simplification.dto.request.ChatGPTRequest;
 import com.adoonge.seedzip.simplification.dto.response.ChatGPTResponse;
 import com.adoonge.seedzip.simplification.dto.response.SimplificationAllResponse;
@@ -12,6 +16,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.InputStream;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +46,11 @@ public class SimplificationService {
     private final RestTemplate template;
     private final NaverNewsService naverNewsService;
     private final S3Service s3Service;
+
+    private final MemberAiUsageRepository memberAiUsageRepository;
+    private final MemberRepository memberRepository;
+
+    private final static int DAILY_AI_LIMIT = 5;
 
     /**
      * 기존 버전
@@ -283,5 +293,27 @@ public class SimplificationService {
             throw SeedzipException.from(ErrorCode.INTERNAL_SEVER_ERROR);
         }
     }
+
+    public void checkDailyAiUsage(Member member) {
+        LocalDate today = LocalDate.now();
+        MemberAiUsages memberAiUsages = memberAiUsageRepository.findByMemberId(member.getId())
+            .orElseGet(() -> createMemberAiUsage(member, today));
+
+        if(memberAiUsages.getUsageCount() > DAILY_AI_LIMIT) {
+            throw SeedzipException.from(ErrorCode.DAILY_AI_LIMIT_EXCEEDED);
+        }
+
+        memberAiUsages.increaseUsageCount();
+        memberAiUsageRepository.save(memberAiUsages);
+    }
+
+    private MemberAiUsages createMemberAiUsage(Member member, LocalDate today) {
+        return MemberAiUsages.builder()
+            .memberId(member)
+            .usageCount(0L)
+            .lastUsedDate(today)
+            .build();
+    }
+
 
 }

--- a/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
@@ -300,7 +300,7 @@ public class SimplificationService {
         MemberAiUsages memberAiUsages = memberAiUsageRepository.findByMemberId(member.getId())
             .orElseGet(() -> createMemberAiUsage(member, today));
 
-        if(memberAiUsages.getUsageCount() > DAILY_AI_LIMIT) {
+        if(memberAiUsages.getUsageCount() >= DAILY_AI_LIMIT) {
             throw SeedzipException.from(ErrorCode.DAILY_AI_LIMIT_EXCEEDED);
         }
 

--- a/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
+++ b/src/main/java/com/adoonge/seedzip/simplification/service/SimplificationService.java
@@ -28,6 +28,7 @@ import org.apache.pdfbox.text.PDFTextStripper;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
@@ -309,10 +310,16 @@ public class SimplificationService {
 
     private MemberAiUsages createMemberAiUsage(Member member, LocalDate today) {
         return MemberAiUsages.builder()
-            .memberId(member)
+            .member(member)
             .usageCount(0L)
             .lastUsedDate(today)
             .build();
+    }
+
+    @Scheduled(cron = "0 0 0 * * ?")    // 매일 0시에 실행
+    public void resetDailyAiUsage() {
+        LocalDate today = LocalDate.now();
+        memberAiUsageRepository.deleteByLastUsedDateBefore(today);
     }
 
 


### PR DESCRIPTION
## 🪺 Summary
- 컨트롤러를 V1, V2로 분리하였습니다
- member_ai_usage 테이블로 유저의 일일 ai 사용량을 기록하고 일정 횟수 초과시 에러가 발생합니다
- 테이블은 매일 00:00에 초기화 합니다

<img width="475" alt="스크린샷 2025-03-14 오전 1 53 52" src="https://github.com/user-attachments/assets/fb610d34-09c7-4973-b030-1efc65c43920" />

잘못된 링크 입력 (네이버 뉴스, 유튜브 이외)

<img width="588" alt="스크린샷 2025-03-14 오전 1 56 42" src="https://github.com/user-attachments/assets/c405e80f-ed56-4c69-98d6-2c1b1c2bc7a7" />

분석 횟수 초과

<img width="1273" alt="스크린샷 2025-03-14 오전 1 54 33" src="https://github.com/user-attachments/assets/1ef79ea4-78d1-4875-bfbc-b77ea52c9b23" />

기본 응답


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #117 


## 🙏 To Reviewers
