### PR TITLE
Feat : 전체 씨드 모아보기, 카테고리 내 씨드 모아보기 기능 구현 (#121)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,6 +48,32 @@ public class SeedController {
         Member member = customUserDetails.getMember();
 
         SeedResponse.getAllSeeds getAllSeeds = seedService.getAllSeeds(member, page, size, sortBy, isAsc, seedType);
+        return new ApiResponse<>(getAllSeeds);
+    }
+
+    @GetMapping("/{categoryId}")
+    @Operation(summary = "카테고리 내 씨드 모아보기 API", description = "카테고리에 해당하는 콘텐츠를 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SeedResponse.getAllSeeds.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.getAllSeeds> getCategorySeeds(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "9") int size,
+            @RequestParam(defaultValue = "latest") String sortBy, // latest or name
+            @RequestParam(defaultValue = "false") boolean isAsc,
+            @RequestParam(required = false) String seedType,
+            @PathVariable("categoryId") Long categoryId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        // 빈 값 처리
+        if (sortBy.isBlank()) sortBy = "latest";
+
+        Member member = customUserDetails.getMember();
+
+        SeedResponse.getAllSeeds getAllSeeds = seedService.getCategorySeeds(member, page, size, sortBy, isAsc, seedType, categoryId);
         return new ApiResponse<>(getAllSeeds);
     }
 

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -31,10 +31,10 @@ public class SeedController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = SeedResponse.getAllSeeds.class))),
+                            schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ApiResponse<SeedResponse.getAllSeeds> getAllSeeds(
+    public ApiResponse<SeedResponse.GetAllSeeds> getAllSeeds(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "9") int size,
             @RequestParam(defaultValue = "latest") String sortBy, // latest or name
@@ -42,12 +42,9 @@ public class SeedController {
             @RequestParam(required = false) String seedType,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        // 빈 값 처리
-        if (sortBy.isBlank()) sortBy = "latest";
-
         Member member = customUserDetails.getMember();
 
-        SeedResponse.getAllSeeds getAllSeeds = seedService.getAllSeeds(member, page, size, sortBy, isAsc, seedType);
+        SeedResponse.GetAllSeeds getAllSeeds = seedService.getAllSeeds(member, page, size, sortBy, isAsc, seedType);
         return new ApiResponse<>(getAllSeeds);
     }
 
@@ -56,10 +53,10 @@ public class SeedController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = SeedResponse.getAllSeeds.class))),
+                            schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ApiResponse<SeedResponse.getAllSeeds> getCategorySeeds(
+    public ApiResponse<SeedResponse.GetAllSeeds> getCategorySeeds(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "9") int size,
             @RequestParam(defaultValue = "latest") String sortBy, // latest or name
@@ -68,12 +65,9 @@ public class SeedController {
             @PathVariable("categoryId") Long categoryId,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
-        // 빈 값 처리
-        if (sortBy.isBlank()) sortBy = "latest";
-
         Member member = customUserDetails.getMember();
 
-        SeedResponse.getAllSeeds getAllSeeds = seedService.getCategorySeeds(member, page, size, sortBy, isAsc, seedType, categoryId);
+        SeedResponse.GetAllSeeds getAllSeeds = seedService.getCategorySeeds(member, page, size, sortBy, isAsc, seedType, categoryId);
         return new ApiResponse<>(getAllSeeds);
     }
 

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -35,7 +35,7 @@ public class SeedController {
     })
     public ApiResponse<SeedResponse.getAllSeeds> getAllSeeds(
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "9") int size,
             @RequestParam(defaultValue = "latest") String sortBy, // latest or name
             @RequestParam(defaultValue = "false") boolean isAsc,
             @RequestParam(required = false) String seedType,

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,9 +1,20 @@
 package com.adoonge.seedzip.seed.controller;
 
+import com.adoonge.seedzip.auth.util.CustomUserDetails;
+import com.adoonge.seedzip.global.dto.response.ApiResponse;
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.dto.response.SeedResponse;
 import com.adoonge.seedzip.seed.service.SeedService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -13,4 +24,30 @@ import org.springframework.web.bind.annotation.RestController;
 public class SeedController {
 
     private final SeedService seedService;
+
+    @GetMapping
+    @Operation(summary = "전체 씨드 모아보기 API", description = "전체 씨드를 홈화면에서 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SeedResponse.getAllSeeds.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.getAllSeeds> getAllSeeds(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "latest") String sortBy, // latest or name
+            @RequestParam(defaultValue = "false") boolean isAsc,
+            @RequestParam(required = false) String seedType,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        // 빈 값 처리
+        if (sortBy.isBlank()) sortBy = "latest";
+
+        Member member = customUserDetails.getMember();
+
+        SeedResponse.getAllSeeds getAllSeeds = seedService.getAllSeeds(member, page, size, sortBy, isAsc, seedType);
+        return new ApiResponse<>(getAllSeeds);
+    }
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
@@ -1,6 +1,7 @@
 package com.adoonge.seedzip.seed.dto.response;
 
 import com.adoonge.seedzip.content.domain.ContentsDataType;
+import com.adoonge.seedzip.seed.domain.SeedType;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -31,7 +32,7 @@ public class SeedResponse {
         String seedName;
         List<Long> categoryId;
         List<String> categoryName;
-        ContentsDataType seedDateType;
+        SeedType seedType;
         String thumbnailImage; // 없으면 null
         LocalDateTime updatedDt;
         List<Long> tagId;

--- a/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
@@ -1,52 +1,20 @@
 package com.adoonge.seedzip.seed.dto.response;
-
 import com.adoonge.seedzip.content.domain.ContentsDataType;
 import com.adoonge.seedzip.seed.domain.SeedType;
 import java.time.LocalDateTime;
 import java.util.List;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 public class SeedResponse {
 
     @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class PageInfo {
-        int page;
-        int size;
-        int totalPages;
-        long totalElements;
-        boolean isLast;
-    }
+    public record PageInfo(int page, int size, int totalPages, long totalElements, boolean isLast) {}
 
     @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class seedInfo{
-        Long seedId;
-        String seedName;
-        List<Long> categoryId;
-        List<String> categoryName;
-        SeedType seedType;
-        String thumbnailImage; // 없으면 null
-        LocalDateTime updatedDt;
-        List<Long> tagId;
-        List<String> tagName;
-        int dDay;
-    }
+    public record SeedInfo(Long seedId, String seedName, List<Long> categoryId, List<String> categoryName,
+                           SeedType seedType, String thumbnailImage, LocalDateTime updatedDt,
+                           List<Long> tagId, List<String> tagName, int dDay) {}
 
     @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class getAllSeeds{
-        String nickname;
-        List<seedInfo> seedInfoList;
-        PageInfo pageInfo;
-    }
+    public record GetAllSeeds(String nickname, List<SeedInfo> seedInfoList, PageInfo pageInfo) {}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
@@ -1,0 +1,51 @@
+package com.adoonge.seedzip.seed.dto.response;
+
+import com.adoonge.seedzip.content.domain.ContentsDataType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class SeedResponse {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PageInfo {
+        int page;
+        int size;
+        int totalPages;
+        long totalElements;
+        boolean isLast;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class seedInfo{
+        Long seedId;
+        String seedName;
+        List<Long> categoryId;
+        List<String> categoryName;
+        ContentsDataType seedDateType;
+        String thumbnailImage; // 없으면 null
+        LocalDateTime updatedDt;
+        List<Long> tagId;
+        List<String> tagName;
+        int dDay;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class getAllSeeds{
+        String nickname;
+        List<seedInfo> seedInfoList;
+        PageInfo pageInfo;
+    }
+}

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -1,7 +1,18 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.mapping.CategorySeed;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long> {
+
+    @Query("SELECT cs.category.categoryId FROM CategorySeed cs WHERE cs.seed = :seed")
+    List<Long> findCategoryIdsBySeed(@Param("seed") Seed seed);
+
+    // 자동으로 Inner 조인 사용 , n+1 문제 발생 X
+    @Query("SELECT cs.category.name FROM CategorySeed cs WHERE cs.seed = :seed")
+    List<String> findCategoryNamesBySeed(@Param("seed") Seed seed);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -15,4 +15,7 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
     // 자동으로 Inner 조인 사용 , n+1 문제 발생 X
     @Query("SELECT cs.category.name FROM CategorySeed cs WHERE cs.seed = :seed")
     List<String> findCategoryNamesBySeed(@Param("seed") Seed seed);
+
+    @Query("SELECT cs.seed.id FROM CategorySeed cs WHERE cs.category.categoryId = :categoryId")
+    List<Long> findSeedIdsByCategoryId(@Param("categoryId") Long categoryId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -1,8 +1,16 @@
 package com.adoonge.seedzip.seed.repository;
 
 import com.adoonge.seedzip.seed.domain.File;
+import com.adoonge.seedzip.seed.domain.Seed;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FileRepository extends JpaRepository<File, Long> {
 
+    @Query("SELECT f FROM File f WHERE f.seed = :seed AND f.isThumbnail = true")
+    Optional<File> findThumbnailBySeed(@Param("seed") Seed seed);
+
+    Optional<File> findBySeed(Seed seed);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -1,0 +1,8 @@
+package com.adoonge.seedzip.seed.repository;
+
+import com.adoonge.seedzip.seed.domain.File;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -3,11 +3,19 @@ package com.adoonge.seedzip.seed.repository;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SeedRepository extends JpaRepository<Seed, Long> {
     Page<Seed> findByMember(Member member, Pageable pageable);
     Page<Seed> findByMemberAndSeedType(Member member, SeedType seedType, Pageable pageable);
+
+    @Query("SELECT s FROM Seed s WHERE s.id IN :seedIds")
+    Page<Seed> findBySeedIdIn(List<Long> seedIds, Pageable pageable);
+    @Query("SELECT s FROM Seed s WHERE s.id IN :seedIds AND s.seedType = :seedType")
+    Page<Seed> findBySeedIdInAndSeedType(List<Long> seedIds, SeedType seedType, Pageable pageable);
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -1,7 +1,13 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.domain.SeedType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SeedRepository extends JpaRepository<Seed, Long> {
+    Page<Seed> findByMember(Member member, Pageable pageable);
+    Page<Seed> findByMemberAndSeedType(Member member, SeedType seedType, Pageable pageable);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -1,7 +1,18 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
+
+    @Query("SELECT st.tag.id FROM SeedTag st WHERE st.seed = :seed")
+    List<Long> findTagIdsBySeed(@Param("seed") Seed seed);
+
+    // 자동으로 Inner 조인 사용 , n+1 문제 발생 X
+    @Query("SELECT st.tag.tagName FROM SeedTag st WHERE st.seed = :seed")
+    List<String> findTagNamesBySeed(@Param("seed") Seed seed);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,9 +1,31 @@
 package com.adoonge.seedzip.seed.service;
 
+import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.domain.File;
+import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.domain.SeedType;
+import com.adoonge.seedzip.seed.dto.response.SeedResponse;
+import com.adoonge.seedzip.seed.dto.response.SeedResponse.getAllSeeds;
+import com.adoonge.seedzip.seed.repository.CategorySeedRepository;
+import com.adoonge.seedzip.seed.repository.FileRepository;
 import com.adoonge.seedzip.seed.repository.SeedRepository;
+import com.adoonge.seedzip.seed.repository.SeedTagRepository;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -11,4 +33,121 @@ import org.springframework.stereotype.Service;
 public class SeedService {
 
     private final SeedRepository seedRepository;
+    private final FileRepository fileRepository;
+    private final CategorySeedRepository categorySeedRepository;
+    private final SeedTagRepository seedTagRepository;
+
+    @Transactional(readOnly = true)
+    public SeedResponse.getAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        String sortField = switch (sortBy) {
+            case "name" -> "seedName";
+            case "latest" -> "createdAt";
+            default -> "createdAt";
+        };
+
+        // 문자열 -> Enum 변환 (대소문자 구분 없이 처리)
+        SeedType parsedSeedType = null;
+        if (seedType != null && !seedType.isBlank()) {
+            try {
+                parsedSeedType = SeedType.valueOf(seedType.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+
+        //페이징을 위한 Pageable 객체
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+
+        //페이징으로 얻어온 Seed 리스트
+        Page<Seed> seedList;
+        if (seedType != null) {
+            seedList = seedRepository.findByMemberAndSeedType(member, parsedSeedType, pageable);
+        } else {
+            seedList = seedRepository.findByMember(member, pageable);
+        }
+
+        if (seedList.isEmpty())
+            return null;
+
+        List<SeedResponse.seedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+
+        //페이징 정보 추가
+        SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+                .page(seedList.getNumber())
+                .size(seedList.getSize())
+                .totalPages(seedList.getTotalPages())
+                .totalElements(seedList.getTotalElements())
+                .isLast(seedList.isLast())
+                .build();
+
+        SeedResponse.getAllSeeds getAllSeeds = new getAllSeeds().builder()
+                .nickname(member.getNickname())
+                .seedInfoList(seedInfoList)
+                .pageInfo(pageInfo)
+                .build();
+
+        return getAllSeeds;
+    }
+
+    //List<Seed> -> List<SeedResponse.seedInfo>로 변환
+    private List<SeedResponse.seedInfo> generateResponseFromSeedList(List<Seed> seedList) {
+        //여기 작성하기 + 카테고리 이름이랑 태그 이름 어떻게 효과적으로 가져올지 찾아보기
+        return seedList.stream()
+                .map(seed -> {
+                    String thumbnailUrl = null;
+                    //링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
+                    if(seed.getSeedType().equals(SeedType.LINK)){
+                        Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
+                        if(thumbnailFile.isPresent()){
+                            thumbnailUrl = thumbnailFile.get().getLink();
+                        }
+                    }
+                    // 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
+                    else {
+                        Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
+                        if(thumbnailFile.isPresent()){
+                            thumbnailUrl = thumbnailFile.get().getLink();
+                        }
+                    }
+
+                    //seedId에 해당하는 카테고리 리스트 조회
+                    List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
+                    List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
+
+                    //seedId에 해당하는 태그 리스트 조회
+                    List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
+                    List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
+
+                    // D-day 계산
+                    int dDayValue = 1;
+                    if (seed.getDDay() != null) {
+                        LocalDate today = LocalDate.now();
+                        long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
+
+                        if (daysBetween > 0) {
+                            dDayValue = -(int)daysBetween;
+                        } else if (daysBetween == 0) {
+                            dDayValue = 0;
+                        }
+                    }
+
+                    // SeedResponse 객체에 필요한 정보 담기
+                    return new SeedResponse.seedInfo(
+                            seed.getId(),
+                            seed.getSeedName(),
+                            categoryIds,
+                            categoryNames,
+                            seed.getSeedType(),
+                            thumbnailUrl,
+                            seed.getUpdatedAt(),
+                            tagIds,
+                            tagNames,
+                            dDayValue
+                    );
+
+                })
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -37,23 +37,10 @@ public class SeedService {
 
     @Transactional(readOnly = true)
     public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType) {
-        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
 
-        String sortField = switch (sortBy) {
-            case "name" -> "seedName";
-            case "latest" -> "createdAt";
-            default -> "createdAt";
-        };
-
-        // 문자열 -> Enum 변환 (대소문자 구분 없이 처리)
-        SeedType parsedSeedType = null;
-        if (seedType != null && !seedType.isBlank()) {
-            try {
-                parsedSeedType = SeedType.valueOf(seedType.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
-            }
-        }
+        Sort.Direction direction = getSortDirection(isAsc);
+        String sortField = getSortField(sortBy);
+        SeedType parsedSeedType = parseSeedType(seedType);
 
         //페이징을 위한 Pageable 객체
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
@@ -80,34 +67,20 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.GetAllSeeds getAllSeeds = SeedResponse.GetAllSeeds.builder()
+        return SeedResponse.GetAllSeeds.builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)
                 .build();
-
-        return getAllSeeds;
     }
 
     @Transactional(readOnly = true)
     public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType, long categoryId) {
-        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
 
-        String sortField = switch (sortBy) {
-            case "name" -> "seedName";
-            case "latest" -> "createdAt";
-            default -> "createdAt";
-        };
+        Sort.Direction direction = getSortDirection(isAsc);
+        String sortField = getSortField(sortBy);
+        SeedType parsedSeedType = parseSeedType(seedType);
 
-        // 문자열 -> Enum 변환 (대소문자 구분 없이 처리)
-        SeedType parsedSeedType = null;
-        if (seedType != null && !seedType.isBlank()) {
-            try {
-                parsedSeedType = SeedType.valueOf(seedType.toUpperCase());
-            } catch (IllegalArgumentException e) {
-                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
-            }
-        }
 
         //페이징을 위한 Pageable 객체
         Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
@@ -136,18 +109,15 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.GetAllSeeds getAllSeeds = SeedResponse.GetAllSeeds.builder()
+        return SeedResponse.GetAllSeeds.builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)
                 .build();
-
-        return getAllSeeds;
     }
 
     //List<Seed> -> List<SeedResponse.SeedInfo>로 변환
     private List<SeedResponse.SeedInfo> generateResponseFromSeedList(List<Seed> seedList) {
-        //여기 작성하기 + 카테고리 이름이랑 태그 이름 어떻게 효과적으로 가져올지 찾아보기
         return seedList.stream()
                 .map(seed -> {
                     String thumbnailUrl = null;
@@ -203,5 +173,32 @@ public class SeedService {
 
                 })
                 .collect(Collectors.toList());
+    }
+
+    // 정렬 방향을 결정하는 메소드
+    private Sort.Direction getSortDirection(boolean isAsc) {
+        return isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+    }
+
+    // sortBy 값에 따라 필드명을 결정하는 메소드
+    private String getSortField(String sortBy) {
+        return switch (sortBy) {
+            case "name" -> "seedName";
+            case "latest" -> "createdAt";
+            default -> "createdAt";  // 기본값은 "createdAt"으로 설정
+        };
+    }
+
+    // 문자열로 전달된 seedType을 Enum으로 변환하는 메소드
+    private SeedType parseSeedType(String seedType) {
+        if (seedType != null && !seedType.isBlank()) {
+            try {
+                return SeedType.valueOf(seedType.toUpperCase());  // 대소문자 구분 없이 변환
+            } catch (IllegalArgumentException e) {
+                // 잘못된 입력값에 대해 예외를 던짐
+                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+        return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
     }
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,6 +1,5 @@
 package com.adoonge.seedzip.seed.service;
 
-import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
@@ -8,7 +7,7 @@ import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
-import com.adoonge.seedzip.seed.dto.response.SeedResponse.getAllSeeds;
+import com.adoonge.seedzip.seed.dto.response.SeedResponse.GetAllSeeds;
 import com.adoonge.seedzip.seed.repository.CategorySeedRepository;
 import com.adoonge.seedzip.seed.repository.FileRepository;
 import com.adoonge.seedzip.seed.repository.SeedRepository;
@@ -38,7 +37,7 @@ public class SeedService {
     private final SeedTagRepository seedTagRepository;
 
     @Transactional(readOnly = true)
-    public SeedResponse.getAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType) {
+    public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
 
         String sortField = switch (sortBy) {
@@ -71,7 +70,7 @@ public class SeedService {
         if (seedList.isEmpty())
             return null;
 
-        List<SeedResponse.seedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+        List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
 
         //페이징 정보 추가
         SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -82,7 +81,7 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.getAllSeeds getAllSeeds = new getAllSeeds().builder()
+        SeedResponse.GetAllSeeds getAllSeeds = GetAllSeeds.builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)
@@ -92,7 +91,7 @@ public class SeedService {
     }
 
     @Transactional(readOnly = true)
-    public SeedResponse.getAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType, long categoryId) {
+    public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType, long categoryId) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
 
         String sortField = switch (sortBy) {
@@ -127,7 +126,7 @@ public class SeedService {
         if (seedList.isEmpty())
             return null;
 
-        List<SeedResponse.seedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+        List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
 
         //페이징 정보 추가
         SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -138,7 +137,7 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.getAllSeeds getAllSeeds = new getAllSeeds().builder()
+        SeedResponse.GetAllSeeds getAllSeeds = new SeedResponse.GetAllSeeds().builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)
@@ -147,8 +146,8 @@ public class SeedService {
         return getAllSeeds;
     }
 
-    //List<Seed> -> List<SeedResponse.seedInfo>로 변환
-    private List<SeedResponse.seedInfo> generateResponseFromSeedList(List<Seed> seedList) {
+    //List<Seed> -> List<SeedResponse.SeedInfo>로 변환
+    private List<SeedResponse.SeedInfo> generateResponseFromSeedList(List<Seed> seedList) {
         //여기 작성하기 + 카테고리 이름이랑 태그 이름 어떻게 효과적으로 가져올지 찾아보기
         return seedList.stream()
                 .map(seed -> {
@@ -190,7 +189,7 @@ public class SeedService {
                     }
 
                     // SeedResponse 객체에 필요한 정보 담기
-                    return new SeedResponse.seedInfo(
+                    return new SeedResponse.SeedInfo(
                             seed.getId(),
                             seed.getSeedName(),
                             categoryIds,

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -7,7 +7,6 @@ import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
-import com.adoonge.seedzip.seed.dto.response.SeedResponse.GetAllSeeds;
 import com.adoonge.seedzip.seed.repository.CategorySeedRepository;
 import com.adoonge.seedzip.seed.repository.FileRepository;
 import com.adoonge.seedzip.seed.repository.SeedRepository;
@@ -81,7 +80,7 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.GetAllSeeds getAllSeeds = GetAllSeeds.builder()
+        SeedResponse.GetAllSeeds getAllSeeds = SeedResponse.GetAllSeeds.builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)
@@ -137,7 +136,7 @@ public class SeedService {
                 .isLast(seedList.isLast())
                 .build();
 
-        SeedResponse.GetAllSeeds getAllSeeds = new SeedResponse.GetAllSeeds().builder()
+        SeedResponse.GetAllSeeds getAllSeeds = SeedResponse.GetAllSeeds.builder()
                 .nickname(member.getNickname())
                 .seedInfoList(seedInfoList)
                 .pageInfo(pageInfo)

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -91,6 +91,62 @@ public class SeedService {
         return getAllSeeds;
     }
 
+    @Transactional(readOnly = true)
+    public SeedResponse.getAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType, long categoryId) {
+        Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+
+        String sortField = switch (sortBy) {
+            case "name" -> "seedName";
+            case "latest" -> "createdAt";
+            default -> "createdAt";
+        };
+
+        // 문자열 -> Enum 변환 (대소문자 구분 없이 처리)
+        SeedType parsedSeedType = null;
+        if (seedType != null && !seedType.isBlank()) {
+            try {
+                parsedSeedType = SeedType.valueOf(seedType.toUpperCase());
+            } catch (IllegalArgumentException e) {
+                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+            }
+        }
+
+        //페이징을 위한 Pageable 객체
+        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+
+        List<Long> seedIds = categorySeedRepository.findSeedIdsByCategoryId(categoryId);
+
+        //페이징으로 얻어온 Seed 리스트
+        Page<Seed> seedList;
+        if (seedType != null) {
+            seedList = seedRepository.findBySeedIdInAndSeedType(seedIds, parsedSeedType, pageable);
+        } else {
+            seedList = seedRepository.findBySeedIdIn(seedIds, pageable);
+        }
+
+        if (seedList.isEmpty())
+            return null;
+
+        List<SeedResponse.seedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+
+        //페이징 정보 추가
+        SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+                .page(seedList.getNumber())
+                .size(seedList.getSize())
+                .totalPages(seedList.getTotalPages())
+                .totalElements(seedList.getTotalElements())
+                .isLast(seedList.isLast())
+                .build();
+
+        SeedResponse.getAllSeeds getAllSeeds = new getAllSeeds().builder()
+                .nickname(member.getNickname())
+                .seedInfoList(seedInfoList)
+                .pageInfo(pageInfo)
+                .build();
+
+        return getAllSeeds;
+    }
+
     //List<Seed> -> List<SeedResponse.seedInfo>로 변환
     private List<SeedResponse.seedInfo> generateResponseFromSeedList(List<Seed> seedList) {
         //여기 작성하기 + 카테고리 이름이랑 태그 이름 어떻게 효과적으로 가져올지 찾아보기


### PR DESCRIPTION
## 🪺 Summary
전체 씨드 모아보기, 카테고리 내 씨드 모아보기 기능 구현 완료했습니다!

원래 응답코드에 페이지 관련 정보 있어서 그거 사용하려 했는데, 
페이징된 엔티티들을 DTO로 바꿔줘야 해서 DTO안에 페이징 정보를 넣었습니다.
<img width="256" alt="image" src="https://github.com/user-attachments/assets/9b728d29-0786-4095-ba8b-c4a5a06f27ca" />

그리고 이전에는 카테고리/태그 아이디 리스트를 매핑 테이블에서 가져온 다음에, 카테고리/태그 이름을 하나씩 리스트에 추가하는 방식이였는데,
매핑 테이블 레포지토리에서 한 번에 카테고리 이름들과 태그 이름들을 가져올 수 있도록 JPQL을 짜봤습니다.
전에는 카테고리가 없을시, 태그가 없을 시 이런 제약조건 때문에 그랬던거 같은데, 지금은 카테고리가 없을 수가 없고, 태그 또한 없을 수 없다고 생각해서 짜봤습니다.

<img width="578" alt="image" src="https://github.com/user-attachments/assets/764ec8b6-833c-433d-a4ac-5db710a5addb" />
<img width="525" alt="image" src="https://github.com/user-attachments/assets/4d9a0d84-d1dd-4334-bedf-b1ce97c771c4" />


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #121


## 🙏 To Reviewers
Seed 추가를 할 수 없어서 아직 테스트는 못해봤는데, 추가되면 테스트해보겠습니다!