### PR TITLE
[Refactor] Seed의 POST 관련 메서드 리팩토링 #121

### DIFF
--- a/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
+++ b/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
@@ -3,8 +3,6 @@ package com.adoonge.seedzip.category.repository;
 import java.util.List;
 import java.util.Optional;
 
-import javax.swing.text.html.Option;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
+++ b/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
@@ -3,6 +3,8 @@ package com.adoonge.seedzip.category.repository;
 import java.util.List;
 import java.util.Optional;
 
+import javax.swing.text.html.Option;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -13,5 +15,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
 	List<Category> findAllByMemberId(Long memberId);
 
-	Category findByMemberIdAndName(Long memberId, String name);
+	Optional<Category> findByMemberIdAndName(Long memberId, String name);
 }

--- a/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
+++ b/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
@@ -30,6 +30,11 @@ public class CategoryService {
 
 	@Transactional
 	public CategoryResponse createCategory(AddCategoryRequest request, Member member) {
+		categoryRepository.findByMemberIdAndName(member.getId(), request.name()).
+			ifPresent( category -> {
+				throw SeedzipException.from(ErrorCode.CATEGORY_ALREADY_EXISTS);
+			});
+
 		Category category = categoryRepository.save(request.toEntity(member));
 		return CategoryResponse.fromEntity(category);
 	}

--- a/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
+++ b/src/main/java/com/adoonge/seedzip/content/service/ContentsService.java
@@ -85,13 +85,14 @@ public class ContentsService {
 		}
 
 		if (Objects.isNull(request.getBoardCategory())) {
-			Category category = categoryRepository.findByMemberIdAndName(member.getId(), "default");
+			Optional<Category> category = categoryRepository.findByMemberIdAndName(member.getId(), "default");
 			request.setBoardCategory(new String[] {"default"});
 		}
 
 		// 카테고리 저장
 		Arrays.stream(request.getBoardCategory())  // String[]을 스트림으로 변환
-			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName))
+			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND))) // Category 엔티티 찾기
 			.forEach(category -> {
 				CategoryContent categoryContent = new CategoryContent();
 				categoryContent.setContents(contents); // Content 엔티티는 이미 존재한다고 가정
@@ -482,7 +483,7 @@ public class ContentsService {
 
 		// 카테고리
 		if (Objects.isNull(request.getBoardCategory())) {
-			Category category = categoryRepository.findByMemberIdAndName(member.getId(), "default");
+			Optional<Category> category = categoryRepository.findByMemberIdAndName(member.getId(), "default");
 			request.setBoardCategory(new String[] {"default"});
 		}
 
@@ -520,14 +521,16 @@ public class ContentsService {
 		categoriesToAdd.forEach(categoryName -> {
 			if (categoryName == null || categoryName.trim().isEmpty()) {
 				// 입력받은 카테고리가 없는 경우 default 카테고리 사용
-				Category defaultCategory = categoryRepository.findByMemberIdAndName(member.getId(), "default");
+				Category defaultCategory = categoryRepository.findByMemberIdAndName(member.getId(), "default")
+					.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND));
 				CategoryContent categoryContent = CategoryContent.builder()
 					.contents(contents)
 					.category(defaultCategory)
 					.build();
 				categoryContentRepository.save(categoryContent);
 			} else {
-				Category existingCategory = categoryRepository.findByMemberIdAndName(member.getId(), categoryName);
+				Category existingCategory = categoryRepository.findByMemberIdAndName(member.getId(), categoryName)
+					.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND));
 				if (existingCategory != null) {
 					CategoryContent categoryContent = CategoryContent.builder()
 						.contents(contents)

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -35,6 +35,7 @@ public enum ErrorCode {
     INVALID_SOCIAL_CODE(HttpStatus.BAD_REQUEST, "잘못된 소셜코드입니다."),
 
     // file
+    EMPTY_LINK(HttpStatus.BAD_REQUEST, "링크가 비어있습니다."),
     EMPTY_IMAGE(HttpStatus.BAD_REQUEST, "이미지 파일이 비어있습니다."),
     UNSUPPORTED_IMAGE_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 이미지 파일 확장자입니다."),
     IMAGE_STORE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 저장에 실패했습니다."),

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -90,8 +90,9 @@ public class SeedController {
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         Member member = customUserDetails.getMember();
+        SeedResponse.SeedInfo seedInfoApiResponse = seedService.uploadSeed(seedRequest, member);
 
-        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+        return new ApiResponse<>(seedInfoApiResponse);
     }
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -77,7 +77,8 @@ public class SeedController {
     }
 
     @PostMapping
-    @Operation(summary = "씨드 업로드 API", description = "씨드를 업로드하는 API입니다.")
+    @Operation(summary = "씨드 업로드 API", description = "씨드를 업로드하는 API입니다. 타입, 카테고리, 태그 2개 이상 필수입니다. "
+        + "\n업로드 후, 업로드된 씨드의 ID를 반환합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -85,12 +85,12 @@ public class SeedController {
                             schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ApiResponse<SeedResponse.SeedInfo> uploadSeed(
+    public ApiResponse<SeedResponse.SeedInfoSimple> uploadSeed(
             @RequestBody @Valid SeedRequest seedRequest,
             @AuthenticationPrincipal CustomUserDetails customUserDetails) {
 
         Member member = customUserDetails.getMember();
-        SeedResponse.SeedInfo seedInfoApiResponse = seedService.uploadSeed(seedRequest, member);
+        SeedResponse.SeedInfoSimple seedInfoApiResponse = seedService.uploadSeed(seedRequest, member);
 
         return new ApiResponse<>(seedInfoApiResponse);
     }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -2,7 +2,9 @@ package com.adoonge.seedzip.seed.controller;
 
 import com.adoonge.seedzip.auth.util.CustomUserDetails;
 import com.adoonge.seedzip.global.dto.response.ApiResponse;
+import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.dto.reqeust.SeedRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
 import com.adoonge.seedzip.seed.service.SeedService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -10,10 +12,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -69,6 +74,23 @@ public class SeedController {
 
         SeedResponse.GetAllSeeds getAllSeeds = seedService.getCategorySeeds(member, page, size, sortBy, isAsc, seedType, categoryId);
         return new ApiResponse<>(getAllSeeds);
+    }
+
+    @PostMapping
+    @Operation(summary = "씨드 업로드 API", description = "씨드를 업로드하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.SeedInfo> uploadSeed(
+            @RequestBody @Valid SeedRequest seedRequest,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,5 +1,7 @@
 package com.adoonge.seedzip.seed.controller;
 
+import java.util.List;
+
 import com.adoonge.seedzip.auth.util.CustomUserDetails;
 import com.adoonge.seedzip.global.dto.response.ApiResponse;
 import com.adoonge.seedzip.global.exception.ErrorCode;
@@ -8,6 +10,7 @@ import com.adoonge.seedzip.seed.dto.reqeust.SeedRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
 import com.adoonge.seedzip.seed.service.SeedService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/seed")
@@ -94,5 +98,26 @@ public class SeedController {
 
         return new ApiResponse<>(seedInfoApiResponse);
     }
+
+    @PostMapping("/upload/{seedId}")
+    @Operation(summary = "씨드 업로드 후 파일 업로드 API", description = "씨드를 생성 후 파일을 db 및 aws에 저장하는 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<?> uploadFiles(
+        @PathVariable("seedId") Long seedId,
+        @Parameter(description = "업로드할 파일 리스트", content = @Content(mediaType = "application/octet-stream"))
+        @RequestParam(value = "file", required = false) List<MultipartFile> files,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        seedService.uploadFiles(seedId, files);
+
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+    }
+
+
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -17,6 +17,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -99,7 +101,7 @@ public class SeedController {
         return new ApiResponse<>(seedInfoApiResponse);
     }
 
-    @PostMapping("/upload/{seedId}")
+    @PostMapping(value = "/upload/{seedId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "씨드 업로드 후 파일 업로드 API", description = "씨드를 생성 후 파일을 db 및 aws에 저장하는 API입니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",

--- a/src/main/java/com/adoonge/seedzip/seed/domain/File.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/File.java
@@ -45,9 +45,18 @@ public class File extends BaseEntity {
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Seed seed;
 
-	@Builder
+	@Builder(builderMethodName = "linkBuilder")
 	public File(String link, Seed seed){
 		this.link = link;
 		this.seed = seed;
 	}
+
+	@Builder(builderMethodName = "fileBuilder")
+	public File(String link, String fileName, Boolean isThumbnail, Seed seed) {
+		this.link = link;
+		this.fileName = fileName;
+		this.isThumbnail = isThumbnail;
+		this.seed = seed;
+	}
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/domain/File.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/File.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @Entity
 @Table(name = "files")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,4 +44,10 @@ public class File extends BaseEntity {
 	@JoinColumn(name = "seed_id")
 	@OnDelete(action = OnDeleteAction.CASCADE)
 	private Seed seed;
+
+	@Builder
+	public File(String link, Seed seed){
+		this.link = link;
+		this.seed = seed;
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/SeedDTO.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/SeedDTO.java
@@ -2,6 +2,7 @@ package com.adoonge.seedzip.seed.dto;
 
 import java.time.LocalDate;
 
+import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
 
@@ -14,7 +15,8 @@ public record SeedDTO(
 	@NotNull String seedName,
 	Long thumbnailImage,    // 없으면 null
 	LocalDate dDay,    // 없으면 null
-	String seedDetail    // 없으면 null
+	String seedDetail,   // 없으면 null
+	Member member
 ) {
 
 	public Seed toEntity() {
@@ -24,6 +26,7 @@ public record SeedDTO(
 			.seedDetail(seedDetail)
 			.thumbnailIdx(thumbnailImage)
 			.seedType(seedType)
+			.member(member)
 			.build();
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/SeedDTO.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/SeedDTO.java
@@ -1,0 +1,29 @@
+package com.adoonge.seedzip.seed.dto;
+
+import java.time.LocalDate;
+
+import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.domain.SeedType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record SeedDTO(
+	@NotNull SeedType seedType,
+	@NotNull String seedName,
+	Long thumbnailImage,    // 없으면 null
+	LocalDate dDay,    // 없으면 null
+	String seedDetail    // 없으면 null
+) {
+
+	public Seed toEntity() {
+		return Seed.builder()
+			.seedName(seedName)
+			.dDay(dDay)
+			.seedDetail(seedDetail)
+			.thumbnailIdx(thumbnailImage)
+			.seedType(seedType)
+			.build();
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/seed/dto/reqeust/SeedRequest.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/reqeust/SeedRequest.java
@@ -9,7 +9,7 @@ import jakarta.validation.constraints.NotNull;
 public record SeedRequest(
 	@NotNull SeedType seedType,
 	String seedName,    // 없으면 null
-	@NotNull String[] boardCategory,
+	@NotNull String[] boardCategories,
 	Long thumbnailImage,	// 없으면 null
 	String contentLink, // link만 해당, 나머지 null
 	@NotNull String[] tags,

--- a/src/main/java/com/adoonge/seedzip/seed/dto/reqeust/SeedRequest.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/reqeust/SeedRequest.java
@@ -1,0 +1,19 @@
+package com.adoonge.seedzip.seed.dto.reqeust;
+
+import java.time.LocalDate;
+
+import com.adoonge.seedzip.seed.domain.SeedType;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SeedRequest(
+	@NotNull SeedType seedType,
+	String seedName,    // 없으면 null
+	@NotNull String[] boardCategory,
+	Long thumbnailImage,	// 없으면 null
+	String contentLink, // link만 해당, 나머지 null
+	@NotNull String[] tags,
+	LocalDate dDay,	// 없으면 null
+	String seedDetail	// 없으면 null
+) {
+}

--- a/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
@@ -17,4 +17,7 @@ public class SeedResponse {
 
     @Builder
     public record GetAllSeeds(String nickname, List<SeedInfo> seedInfoList, PageInfo pageInfo) {}
+
+    @Builder
+    public record SeedInfoSimple(Long seedId, String seedName){}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -1,14 +1,19 @@
 package com.adoonge.seedzip.seed.service;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
+import com.adoonge.seedzip.global.service.S3Service;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.domain.SeedType;
 import com.adoonge.seedzip.seed.repository.FileRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -21,11 +26,12 @@ import lombok.extern.slf4j.Slf4j;
 public class FileService {
 
 	private final FileRepository fileRepository;
+	private final S3Service s3Service;
 
 	@Transactional
 	public void saveLink(String contentLink, Seed seed) {
 		fileRepository.save(
-			File.builder()
+			File.linkBuilder()
 				.link(contentLink)
 				.seed(seed)
 				.build()
@@ -35,6 +41,33 @@ public class FileService {
 
 	@Transactional
 	public void saveFiles(List<MultipartFile> files, Seed seed) {
+		AtomicInteger index = new AtomicInteger(0);
+		long thumbnailIndex = seed.getThumbnailIdx();
 
+		files.forEach(
+			file -> {
+				try {
+					String fileLink;
+					if(seed.getSeedType() == SeedType.IMAGE){
+						fileLink = s3Service.uploadImgFile(file);
+					}else{
+						fileLink = s3Service.uploadDocFile(file);
+					}
+
+					fileRepository.save(
+						File.fileBuilder()
+							.link(fileLink)
+							.fileName(file.getOriginalFilename())
+							.isThumbnail(index.get() == thumbnailIndex)
+							.seed(seed)
+							.build()
+					);
+
+					index.getAndIncrement();
+				} catch (Exception e) {
+					throw SeedzipException.from(ErrorCode.S3_UPLOAD_FAILURE);
+				}
+			}
+		);
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -10,7 +10,6 @@ import org.springframework.web.multipart.MultipartFile;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.global.service.S3Service;
-import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -1,0 +1,30 @@
+package com.adoonge.seedzip.seed.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.adoonge.seedzip.seed.domain.File;
+import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.repository.FileRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Service
+@Slf4j
+@Transactional(readOnly = true)
+public class FileService {
+	private final FileRepository fileRepository;
+
+@Transactional
+	public void saveLink(String contentLink, Seed seed) {
+		fileRepository.save(
+			File.builder()
+				.link(contentLink)
+				.seed(seed)
+				.build()
+		);
+
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -1,8 +1,12 @@
 package com.adoonge.seedzip.seed.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.repository.FileRepository;
@@ -15,9 +19,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Transactional(readOnly = true)
 public class FileService {
+
 	private final FileRepository fileRepository;
 
-@Transactional
+	@Transactional
 	public void saveLink(String contentLink, Seed seed) {
 		fileRepository.save(
 			File.builder()
@@ -25,6 +30,11 @@ public class FileService {
 				.seed(seed)
 				.build()
 		);
+
+	}
+
+	@Transactional
+	public void saveFiles(List<MultipartFile> files, Seed seed) {
 
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -171,7 +171,7 @@ public class SeedService {
 			.build();
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public void uploadFiles(Long seedId, List<MultipartFile> files) {
 		Seed seed = seedRepository.findById(seedId).orElseThrow(
 			() -> SeedzipException.from(ErrorCode.CONTENT_NOT_FOUND)

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -174,7 +174,7 @@ public class SeedService {
 		SeedDTO seedDTO = SeedDTO.builder()
 			.seedName(seedRequest.seedName() == null ? LocalDate.now().toString() : seedRequest.seedName())
 			.seedDetail(seedRequest.seedDetail())
-			.thumbnailImage(seedRequest.seedType() == SeedType.LINK ? null : seedRequest.thumbnailImage())
+			.thumbnailImage(seedRequest.thumbnailImage() == null ? 0 : seedRequest.thumbnailImage())
 			.dDay(seedRequest.dDay())
 			.seedType(seedRequest.seedType())
 			.member(member)

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -26,12 +26,14 @@ import com.adoonge.seedzip.tag.domain.type.DefaultTagType;
 import com.adoonge.seedzip.tag.repository.TagRepository;
 import com.adoonge.seedzip.tag.repository.UsedDefaultTagRepository;
 
+import java.lang.reflect.Array;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -58,6 +60,10 @@ public class SeedService {
 	private final TagRepository tagRepository;
 	private final UsedDefaultTagRepository usedDefaultTagRepository;
 	private final CategoryRepository categoryRepository;
+
+	private static final Set<String> DEFAULT_TAG_NAMES = Arrays.stream(DefaultTagType.values())
+		.map(DefaultTagType::getDisplayName)
+		.collect(Collectors.toSet());
 
 	@Transactional(readOnly = true)
 	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
@@ -166,7 +172,7 @@ public class SeedService {
 
 	private Seed saveSeed(SeedRequest seedRequest, Member member) {
 		SeedDTO seedDTO = SeedDTO.builder()
-			.seedName(seedRequest.seedName() == null ? LocalDateTime.now().toString() : seedRequest.seedName())
+			.seedName(seedRequest.seedName() == null ? LocalDate.now().toString() : seedRequest.seedName())
 			.seedDetail(seedRequest.seedDetail())
 			.thumbnailImage(seedRequest.seedType() == SeedType.LINK ? null : seedRequest.thumbnailImage())
 			.dDay(seedRequest.dDay())
@@ -204,10 +210,8 @@ public class SeedService {
 	}
 
 	private Tag findOrCreateTag(String tagName, Member member) {
-		// 1. Default 태그 확인 (enum 클래스에서)
-		if (Arrays.stream(DefaultTagType.values())
-			.anyMatch(tag -> tag.getDisplayName().equals(tagName))) {
-
+		// 1.default tag 확인
+		if(DEFAULT_TAG_NAMES.contains(tagName)) {
 			Tag defaultTag = tagRepository.findByTagName(tagName)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.TAG_NOT_FOUND));
 
@@ -222,15 +226,13 @@ public class SeedService {
 
 			return defaultTag;
 		}
-
 		// 2. 디폴트 태그가 아닌 경우 CustomTag로 저장
 		return tagRepository.findByTagNameAndMemberId(tagName, member.getId())
-			.orElseGet(() -> {
-				return tagRepository.save(Tag.builder()
+			.orElseGet(() ->
+				tagRepository.save(Tag.builder()
 					.tagName(tagName)
 					.member(member)
-					.build());
-			});
+					.build()));
 	}
 
 	//List<Seed> -> List<SeedResponse.SeedInfo>로 변환

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,23 +1,42 @@
 package com.adoonge.seedzip.seed.service;
 
+import com.adoonge.seedzip.category.repository.CategoryRepository;
+import com.adoonge.seedzip.content.domain.ContentsDataType;
+import com.adoonge.seedzip.content.domain.Link;
+import com.adoonge.seedzip.content.domain.mapping.CategoryContent;
+import com.adoonge.seedzip.content.domain.mapping.ContentTag;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
+import com.adoonge.seedzip.seed.domain.mapping.CategorySeed;
+import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
+import com.adoonge.seedzip.seed.dto.SeedDTO;
+import com.adoonge.seedzip.seed.dto.reqeust.SeedRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
 import com.adoonge.seedzip.seed.repository.CategorySeedRepository;
 import com.adoonge.seedzip.seed.repository.FileRepository;
 import com.adoonge.seedzip.seed.repository.SeedRepository;
 import com.adoonge.seedzip.seed.repository.SeedTagRepository;
+import com.adoonge.seedzip.tag.domain.Tag;
+import com.adoonge.seedzip.tag.domain.UsedDefaultTag;
+import com.adoonge.seedzip.tag.domain.type.DefaultTagType;
+import com.adoonge.seedzip.tag.repository.TagRepository;
+import com.adoonge.seedzip.tag.repository.UsedDefaultTagRepository;
+
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -30,175 +49,264 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class SeedService {
 
-    private final SeedRepository seedRepository;
-    private final FileRepository fileRepository;
-    private final CategorySeedRepository categorySeedRepository;
-    private final SeedTagRepository seedTagRepository;
+	private final SeedRepository seedRepository;
+	private final FileRepository fileRepository;
+	private final CategorySeedRepository categorySeedRepository;
+	private final SeedTagRepository seedTagRepository;
+	private final TagRepository tagRepository;
+	private final UsedDefaultTagRepository usedDefaultTagRepository;
+	private final CategoryRepository categoryRepository;
 
-    @Transactional(readOnly = true)
-    public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType) {
+	@Transactional(readOnly = true)
+	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
+		String seedType) {
 
-        Sort.Direction direction = getSortDirection(isAsc);
-        String sortField = getSortField(sortBy);
-        SeedType parsedSeedType = parseSeedType(seedType);
+		Sort.Direction direction = getSortDirection(isAsc);
+		String sortField = getSortField(sortBy);
+		SeedType parsedSeedType = parseSeedType(seedType);
 
-        //페이징을 위한 Pageable 객체
-        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+		//페이징을 위한 Pageable 객체
+		Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
 
-        //페이징으로 얻어온 Seed 리스트
-        Page<Seed> seedList;
-        if (seedType != null) {
-            seedList = seedRepository.findByMemberAndSeedType(member, parsedSeedType, pageable);
-        } else {
-            seedList = seedRepository.findByMember(member, pageable);
-        }
+		//페이징으로 얻어온 Seed 리스트
+		Page<Seed> seedList;
+		if (seedType != null) {
+			seedList = seedRepository.findByMemberAndSeedType(member, parsedSeedType, pageable);
+		} else {
+			seedList = seedRepository.findByMember(member, pageable);
+		}
 
-        if (seedList.isEmpty())
-            return null;
+		if (seedList.isEmpty())
+			return null;
 
-        List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
 
-        //페이징 정보 추가
-        SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-                .page(seedList.getNumber())
-                .size(seedList.getSize())
-                .totalPages(seedList.getTotalPages())
-                .totalElements(seedList.getTotalElements())
-                .isLast(seedList.isLast())
-                .build();
+		//페이징 정보 추가
+		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+			.page(seedList.getNumber())
+			.size(seedList.getSize())
+			.totalPages(seedList.getTotalPages())
+			.totalElements(seedList.getTotalElements())
+			.isLast(seedList.isLast())
+			.build();
 
-        return SeedResponse.GetAllSeeds.builder()
-                .nickname(member.getNickname())
-                .seedInfoList(seedInfoList)
-                .pageInfo(pageInfo)
-                .build();
-    }
+		return SeedResponse.GetAllSeeds.builder()
+			.nickname(member.getNickname())
+			.seedInfoList(seedInfoList)
+			.pageInfo(pageInfo)
+			.build();
+	}
 
-    @Transactional(readOnly = true)
-    public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc, String seedType, long categoryId) {
+	@Transactional(readOnly = true)
+	public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
+		String seedType, long categoryId) {
 
-        Sort.Direction direction = getSortDirection(isAsc);
-        String sortField = getSortField(sortBy);
-        SeedType parsedSeedType = parseSeedType(seedType);
+		Sort.Direction direction = getSortDirection(isAsc);
+		String sortField = getSortField(sortBy);
+		SeedType parsedSeedType = parseSeedType(seedType);
 
+		//페이징을 위한 Pageable 객체
+		Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
 
-        //페이징을 위한 Pageable 객체
-        Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+		List<Long> seedIds = categorySeedRepository.findSeedIdsByCategoryId(categoryId);
 
-        List<Long> seedIds = categorySeedRepository.findSeedIdsByCategoryId(categoryId);
+		//페이징으로 얻어온 Seed 리스트
+		Page<Seed> seedList;
+		if (seedType != null) {
+			seedList = seedRepository.findBySeedIdInAndSeedType(seedIds, parsedSeedType, pageable);
+		} else {
+			seedList = seedRepository.findBySeedIdIn(seedIds, pageable);
+		}
 
-        //페이징으로 얻어온 Seed 리스트
-        Page<Seed> seedList;
-        if (seedType != null) {
-            seedList = seedRepository.findBySeedIdInAndSeedType(seedIds, parsedSeedType, pageable);
-        } else {
-            seedList = seedRepository.findBySeedIdIn(seedIds, pageable);
-        }
+		if (seedList.isEmpty())
+			return null;
 
-        if (seedList.isEmpty())
-            return null;
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
 
-        List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+		//페이징 정보 추가
+		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+			.page(seedList.getNumber())
+			.size(seedList.getSize())
+			.totalPages(seedList.getTotalPages())
+			.totalElements(seedList.getTotalElements())
+			.isLast(seedList.isLast())
+			.build();
 
-        //페이징 정보 추가
-        SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-                .page(seedList.getNumber())
-                .size(seedList.getSize())
-                .totalPages(seedList.getTotalPages())
-                .totalElements(seedList.getTotalElements())
-                .isLast(seedList.isLast())
-                .build();
+		return SeedResponse.GetAllSeeds.builder()
+			.nickname(member.getNickname())
+			.seedInfoList(seedInfoList)
+			.pageInfo(pageInfo)
+			.build();
+	}
 
-        return SeedResponse.GetAllSeeds.builder()
-                .nickname(member.getNickname())
-                .seedInfoList(seedInfoList)
-                .pageInfo(pageInfo)
-                .build();
-    }
+	@Transactional
+	public SeedResponse.SeedInfo uploadSeed(SeedRequest seedRequest, Member member) {
 
-    //List<Seed> -> List<SeedResponse.SeedInfo>로 변환
-    private List<SeedResponse.SeedInfo> generateResponseFromSeedList(List<Seed> seedList) {
-        return seedList.stream()
-                .map(seed -> {
-                    String thumbnailUrl = null;
-                    //링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
-                    if(seed.getSeedType().equals(SeedType.LINK)){
-                        Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
-                        if(thumbnailFile.isPresent()){
-                            thumbnailUrl = thumbnailFile.get().getLink();
-                        }
-                    }
-                    // 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
-                    else {
-                        Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
-                        if(thumbnailFile.isPresent()){
-                            thumbnailUrl = thumbnailFile.get().getLink();
-                        }
-                    }
+		SeedDTO seedDTO = SeedDTO.builder()
+			.seedName(seedRequest.seedName() == null ? LocalDateTime.now().toString() : seedRequest.seedName())
+			.seedDetail(seedRequest.seedDetail())
+			.thumbnailImage(seedRequest.thumbnailImage())
+			.dDay(seedRequest.dDay())
+			.seedType(seedRequest.seedType())
+			.build();
 
-                    //seedId에 해당하는 카테고리 리스트 조회
-                    List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
-                    List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
+		Seed seed = seedRepository.save(seedDTO.toEntity());
 
-                    //seedId에 해당하는 태그 리스트 조회
-                    List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
-                    List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
+		// 태그 저장
+		for (String tagName : seedRequest.tags()) {
+			Tag tag = findOrCreateTag(tagName, member);
 
-                    // D-day 계산
-                    int dDayValue = 1;
-                    if (seed.getDDay() != null) {
-                        LocalDate today = LocalDate.now();
-                        long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
+			seedTagRepository.save(
+				SeedTag.builder()
+					.seed(seed)
+					.tag(tag)
+					.build()
+			);
+		}
 
-                        if (daysBetween > 0) {
-                            dDayValue = -(int)daysBetween;
-                        } else if (daysBetween == 0) {
-                            dDayValue = 0;
-                        }
-                    }
+		// 카테고리 저장
+		Arrays.stream(seedRequest.boardCategory())
+			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName))
+			.forEach(category -> {
+				categorySeedRepository.save(
+					CategorySeed.builder()
+						.category(category)
+						.seed(seed)
+						.build()
+				);
+			});
 
-                    // SeedResponse 객체에 필요한 정보 담기
-                    return new SeedResponse.SeedInfo(
-                            seed.getId(),
-                            seed.getSeedName(),
-                            categoryIds,
-                            categoryNames,
-                            seed.getSeedType(),
-                            thumbnailUrl,
-                            seed.getUpdatedAt(),
-                            tagIds,
-                            tagNames,
-                            dDayValue
-                    );
+		// LINK 타입의 경우, 링크 정보 저장
+		if (seedRequest.seedType().equals(SeedType.LINK)) {
+			fileRepository.save(
+				File.builder()
+					.link(seedRequest.contentLink())
+					.seed(seed)
+					.build()
+			);
+		}
 
-                })
-                .collect(Collectors.toList());
-    }
+		return SeedResponse.SeedInfo
+			.builder()
+			.seedId(seed.getId())
+			.seedName(seed.getSeedName())
+			.build();
 
-    // 정렬 방향을 결정하는 메소드
-    private Sort.Direction getSortDirection(boolean isAsc) {
-        return isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
-    }
+	}
 
-    // sortBy 값에 따라 필드명을 결정하는 메소드
-    private String getSortField(String sortBy) {
-        return switch (sortBy) {
-            case "name" -> "seedName";
-            case "latest" -> "createdAt";
-            default -> "createdAt";  // 기본값은 "createdAt"으로 설정
-        };
-    }
+	private Tag findOrCreateTag(String tagName, Member member) {
+		// 1. Default 태그 확인 (enum 클래스에서)
+		if (Arrays.stream(DefaultTagType.values())
+			.anyMatch(tag -> tag.getDisplayName().equals(tagName))) {
 
-    // 문자열로 전달된 seedType을 Enum으로 변환하는 메소드
-    private SeedType parseSeedType(String seedType) {
-        if (seedType != null && !seedType.isBlank()) {
-            try {
-                return SeedType.valueOf(seedType.toUpperCase());  // 대소문자 구분 없이 변환
-            } catch (IllegalArgumentException e) {
-                // 잘못된 입력값에 대해 예외를 던짐
-                throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
-            }
-        }
-        return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
-    }
+			Tag defaultTag = tagRepository.findByTagName(tagName)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.TAG_NOT_FOUND));
+
+			// 사용자별 UsedDefaultTag 조회, 저장
+			usedDefaultTagRepository
+				.findByMemberIdAndTagId(member.getId(), defaultTag.getId())    //사용한적 O
+				.orElseGet(() ->    // 사용한적 없으면 저장
+					usedDefaultTagRepository.save(UsedDefaultTag.builder()
+						.member(member)
+						.tag(defaultTag)
+						.build()));
+
+			return defaultTag;
+		}
+
+		// 2. 디폴트 태그가 아닌 경우 CustomTag로 저장
+		return tagRepository.findByTagNameAndMemberId(tagName, member.getId())
+			.orElseGet(() -> {
+				return tagRepository.save(Tag.builder()
+					.tagName(tagName)
+					.member(member)
+					.build());
+			});
+	}
+
+	//List<Seed> -> List<SeedResponse.SeedInfo>로 변환
+	private List<SeedResponse.SeedInfo> generateResponseFromSeedList(List<Seed> seedList) {
+		return seedList.stream()
+			.map(seed -> {
+				String thumbnailUrl = null;
+				//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
+				if (seed.getSeedType().equals(SeedType.LINK)) {
+					Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
+					if (thumbnailFile.isPresent()) {
+						thumbnailUrl = thumbnailFile.get().getLink();
+					}
+				}
+				// 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
+				else {
+					Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
+					if (thumbnailFile.isPresent()) {
+						thumbnailUrl = thumbnailFile.get().getLink();
+					}
+				}
+
+				//seedId에 해당하는 카테고리 리스트 조회
+				List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
+				List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
+
+				//seedId에 해당하는 태그 리스트 조회
+				List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
+				List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
+
+				// D-day 계산
+				int dDayValue = 1;
+				if (seed.getDDay() != null) {
+					LocalDate today = LocalDate.now();
+					long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
+
+					if (daysBetween > 0) {
+						dDayValue = -(int)daysBetween;
+					} else if (daysBetween == 0) {
+						dDayValue = 0;
+					}
+				}
+
+				// SeedResponse 객체에 필요한 정보 담기
+				return new SeedResponse.SeedInfo(
+					seed.getId(),
+					seed.getSeedName(),
+					categoryIds,
+					categoryNames,
+					seed.getSeedType(),
+					thumbnailUrl,
+					seed.getUpdatedAt(),
+					tagIds,
+					tagNames,
+					dDayValue
+				);
+
+			})
+			.collect(Collectors.toList());
+	}
+
+	// 정렬 방향을 결정하는 메소드
+	private Sort.Direction getSortDirection(boolean isAsc) {
+		return isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
+	}
+
+	// sortBy 값에 따라 필드명을 결정하는 메소드
+	private String getSortField(String sortBy) {
+		return switch (sortBy) {
+			case "name" -> "seedName";
+			case "latest" -> "createdAt";
+			default -> "createdAt";  // 기본값은 "createdAt"으로 설정
+		};
+	}
+
+	// 문자열로 전달된 seedType을 Enum으로 변환하는 메소드
+	private SeedType parseSeedType(String seedType) {
+		if (seedType != null && !seedType.isBlank()) {
+			try {
+				return SeedType.valueOf(seedType.toUpperCase());  // 대소문자 구분 없이 변환
+			} catch (IllegalArgumentException e) {
+				// 잘못된 입력값에 대해 예외를 던짐
+				throw SeedzipException.from(ErrorCode.INVALID_INPUT_VALUE);
+			}
+		}
+		return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -45,6 +45,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @RequiredArgsConstructor
 @Service
@@ -168,6 +169,15 @@ public class SeedService {
 			.seedId(seed.getId())
 			.seedName(seed.getSeedName())
 			.build();
+	}
+
+	@Transactional(readOnly = true)
+	public void uploadFiles(Long seedId, List<MultipartFile> files) {
+		Seed seed = seedRepository.findById(seedId).orElseThrow(
+			() -> SeedzipException.from(ErrorCode.CONTENT_NOT_FOUND)
+		);
+
+		fileService.saveFiles(files, seed);
 	}
 
 	private Seed saveSeed(SeedRequest seedRequest, Member member) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -49,6 +49,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class SeedService {
 
+	private final FileService fileService;
+
 	private final SeedRepository seedRepository;
 	private final FileRepository fileRepository;
 	private final CategorySeedRepository categorySeedRepository;
@@ -140,32 +142,43 @@ public class SeedService {
 	}
 
 	@Transactional
-	public SeedResponse.SeedInfo uploadSeed(SeedRequest seedRequest, Member member) {
+	public SeedResponse.SeedInfoSimple uploadSeed(SeedRequest seedRequest, Member member) {
+		if(seedRequest.seedType() == SeedType.LINK && seedRequest.contentLink() == null) {
+			throw SeedzipException.from(ErrorCode.EMPTY_LINK);
+		}
 
+		Seed seed = saveSeed(seedRequest, member);
+
+		// 태그 및 카테고리 저장
+		saveSeedTags(seedRequest.tags(), member, seed);
+		saveSeedCategories(seedRequest.boardCategories(), member, seed);
+
+		if (seedRequest.seedType() == SeedType.LINK) {
+			fileService.saveLink(seedRequest.contentLink(), seed);
+		}
+
+		return SeedResponse.SeedInfoSimple
+			.builder()
+			.seedId(seed.getId())
+			.seedName(seed.getSeedName())
+			.build();
+	}
+
+	private Seed saveSeed(SeedRequest seedRequest, Member member) {
 		SeedDTO seedDTO = SeedDTO.builder()
 			.seedName(seedRequest.seedName() == null ? LocalDateTime.now().toString() : seedRequest.seedName())
 			.seedDetail(seedRequest.seedDetail())
-			.thumbnailImage(seedRequest.thumbnailImage())
+			.thumbnailImage(seedRequest.seedType() == SeedType.LINK ? null : seedRequest.thumbnailImage())
 			.dDay(seedRequest.dDay())
 			.seedType(seedRequest.seedType())
+			.member(member)
 			.build();
 
-		Seed seed = seedRepository.save(seedDTO.toEntity());
+		return seedRepository.save(seedDTO.toEntity());
+	}
 
-		// 태그 저장
-		for (String tagName : seedRequest.tags()) {
-			Tag tag = findOrCreateTag(tagName, member);
-
-			seedTagRepository.save(
-				SeedTag.builder()
-					.seed(seed)
-					.tag(tag)
-					.build()
-			);
-		}
-
-		// 카테고리 저장
-		Arrays.stream(seedRequest.boardCategory())
+	private void saveSeedCategories(String[] boardCategories, Member member, Seed seed) {
+		Arrays.stream(boardCategories)
 			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName))
 			.forEach(category -> {
 				categorySeedRepository.save(
@@ -175,23 +188,19 @@ public class SeedService {
 						.build()
 				);
 			});
+	}
 
-		// LINK 타입의 경우, 링크 정보 저장
-		if (seedRequest.seedType().equals(SeedType.LINK)) {
-			fileRepository.save(
-				File.builder()
-					.link(seedRequest.contentLink())
+	private void saveSeedTags(String[] tags, Member member, Seed seed) {
+		for (String tagName : tags) {
+			Tag tag = findOrCreateTag(tagName, member);
+
+			seedTagRepository.save(
+				SeedTag.builder()
 					.seed(seed)
+					.tag(tag)
 					.build()
 			);
 		}
-
-		return SeedResponse.SeedInfo
-			.builder()
-			.seedId(seed.getId())
-			.seedName(seed.getSeedName())
-			.build();
-
 	}
 
 	private Tag findOrCreateTag(String tagName, Member member) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -185,7 +185,8 @@ public class SeedService {
 
 	private void saveSeedCategories(String[] boardCategories, Member member, Seed seed) {
 		Arrays.stream(boardCategories)
-			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName))
+			.map(categoryName -> categoryRepository.findByMemberIdAndName(member.getId(), categoryName)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.CATEGORY_NOT_FOUND)))
 			.forEach(category -> {
 				categorySeedRepository.save(
 					CategorySeed.builder()


### PR DESCRIPTION
## 🪺 Summary
**Category** 
- 기존에는 중복이 허용되었는데, 콘텐츠 관련 카테고리를 저장할때 이름으로 찾고있어서 중복 허용하지 않도록 변경하였습니다.
- 관련 로직을 개선하면서 기존 content 패키지의 일부 파일들이 수정되었는데, 기능적으로는 영향을 주지 않으므로 신경 쓰지 않으셔도 될것같습니다.

**File**
<img width="645" alt="스크린샷 2025-04-08 오후 2 39 25" src="https://github.com/user-attachments/assets/2db765b2-1b45-4f11-af72-5c298658c2c7" />
- 용도에 맞게 Builder를 분리했습니다.
- 파일을 업로드는 하는 과정관련된 부분은 fileService로 분리했습니다.
- aws 계정 변경 완료했습니다.

**Seed**
<img width="682" alt="스크린샷 2025-04-08 오후 2 42 54" src="https://github.com/user-attachments/assets/0ae08d26-fff1-4d28-8cf0-62f90e1a2fab" />
- 위의 API 사용 후, 이미지 피디에프의 경우 아래 API 추가적으로 사용하면 됩니다.
- SeedDTO 파일은 서비스로직 내부에서 수정 및 관리 용도로 사용했습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #121 

## 🙏 To Reviewers
