### PR TITLE
Refactor: 씨드 상세보기 기능 리팩토링 및 구현

### DIFF
--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -86,6 +86,10 @@ public enum ErrorCode {
     CONTENT_NOT_PUBLISHED(HttpStatus.FORBIDDEN, "이 콘텐츠는 아직 게시되지 않았습니다."),
     CONTENT_ARCHIVED(HttpStatus.GONE, "이 콘텐츠는 보관 처리되었습니다."),
 
+    // seed
+    SEED_NOT_FOUND(HttpStatus.NOT_FOUND, "씨드를 찾을 수 없습니다."),
+
+
     // tag
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다."),
     EMPTY_TAG(HttpStatus.OK, "태그가 존재하지 않습니다."),

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,5 +1,6 @@
 package com.adoonge.seedzip.seed.controller;
 
+import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
 import java.util.List;
 
 import com.adoonge.seedzip.auth.util.CustomUserDetails;
@@ -59,7 +60,7 @@ public class SeedController {
         return new ApiResponse<>(getAllSeeds);
     }
 
-    @GetMapping("/{categoryId}")
+    @GetMapping("/category/{categoryId}")
     @Operation(summary = "카테고리 내 씨드 모아보기 API", description = "카테고리에 해당하는 콘텐츠를 조회하는 API입니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
@@ -82,13 +83,29 @@ public class SeedController {
         return new ApiResponse<>(getAllSeeds);
     }
 
+    @GetMapping("/{seedId}")
+    @Operation(summary = "씨드 상세 보기 API", description = "씨드 내용을 조회하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = ContentsAllResponse.getContents.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.SeedDetail> getSeedDetail(@PathVariable("seedId") Long seedId,
+                                                                          @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+
+        return new ApiResponse<>(seedService.getSeedDetail(seedId, member));
+    }
+
     @PostMapping
     @Operation(summary = "씨드 업로드 API", description = "씨드를 업로드하는 API입니다. 타입, 카테고리, 태그 2개 이상 필수입니다. "
         + "\n업로드 후, 업로드된 씨드의 ID를 반환합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+                            schema = @Schema(implementation = SeedResponse.SeedDetail.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ApiResponse<SeedResponse.SeedInfoSimple> uploadSeed(

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -88,7 +88,7 @@ public class SeedController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = ContentsAllResponse.getContents.class))),
+                            schema = @Schema(implementation = SeedResponse.SeedDetail.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ApiResponse<SeedResponse.SeedDetail> getSeedDetail(@PathVariable("seedId") Long seedId,
@@ -105,7 +105,7 @@ public class SeedController {
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
                     content = @Content(mediaType = "application/json",
-                            schema = @Schema(implementation = SeedResponse.SeedDetail.class))),
+                            schema = @Schema(implementation = SeedResponse.SeedInfo.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ApiResponse<SeedResponse.SeedInfoSimple> uploadSeed(

--- a/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/response/SeedResponse.java
@@ -1,6 +1,6 @@
 package com.adoonge.seedzip.seed.dto.response;
-import com.adoonge.seedzip.content.domain.ContentsDataType;
 import com.adoonge.seedzip.seed.domain.SeedType;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
@@ -20,4 +20,17 @@ public class SeedResponse {
 
     @Builder
     public record SeedInfoSimple(Long seedId, String seedName){}
+
+    @Builder
+    public record SeedDetail(Long seedId,
+            SeedType seedType,
+            String seedName,
+            String seedLink,
+            List<String> fileLinks,
+            List<String> titles,
+            Long thumbnailImage,
+            List<String> categoryNames,
+            List<String> tagNames,
+            LocalDate dDay,
+            String seedDetail){}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -2,6 +2,7 @@ package com.adoonge.seedzip.seed.repository;
 
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,4 +14,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
     Optional<File> findThumbnailBySeed(@Param("seed") Seed seed);
 
     Optional<File> findBySeed(Seed seed);
+
+    Optional<List<File>> findAllBySeed(Seed seed);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -184,22 +185,25 @@ public class SeedService {
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
 
 		String seedLink = null;
-		List<String> fileLinks = new ArrayList<>();
+		List<String> fileLinks = null;
 		Long thumbnailImage = -1L;
-		List<String> titles = new ArrayList<>();
+		List<String> titles = null;
 
 		//링크와 파일들 링크 얻고, 썸네일 처리
         if (seed.getSeedType().equals(SeedType.LINK)) {
             seedLink = files.get(0).getLink();
         } else {
-			int idx = 0;
+			fileLinks = new ArrayList<>();
+			titles = new ArrayList<>();
+			AtomicInteger idx = new AtomicInteger(0);
+
 			for(File file : files){
 				fileLinks.add(file.getLink());
 				titles.add(file.getFileName());
 				if(Boolean.TRUE.equals(file.getIsThumbnail())) {
-					thumbnailImage = (long) idx;
+					thumbnailImage = (long) idx.get();
 				}
-				idx++;
+				idx.getAndIncrement();
 			}
         }
 

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,10 +1,6 @@
 package com.adoonge.seedzip.seed.service;
 
 import com.adoonge.seedzip.category.repository.CategoryRepository;
-import com.adoonge.seedzip.content.domain.ContentsDataType;
-import com.adoonge.seedzip.content.domain.Link;
-import com.adoonge.seedzip.content.domain.mapping.CategoryContent;
-import com.adoonge.seedzip.content.domain.mapping.ContentTag;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
@@ -26,12 +22,12 @@ import com.adoonge.seedzip.tag.domain.type.DefaultTagType;
 import com.adoonge.seedzip.tag.repository.TagRepository;
 import com.adoonge.seedzip.tag.repository.UsedDefaultTagRepository;
 
-import java.lang.reflect.Array;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -178,6 +174,53 @@ public class SeedService {
 		);
 
 		fileService.saveFiles(files, seed);
+	}
+
+	@Transactional(readOnly = true)
+	public SeedResponse.SeedDetail getSeedDetail(Long seedId, Member member) {
+		Seed seed = seedRepository.findById(seedId)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
+		List<File> files = fileRepository.findAllBySeed(seed)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
+
+		String seedLink = null;
+		List<String> fileLinks = new ArrayList<>();
+		Long thumbnailImage = -1L;
+		List<String> titles = new ArrayList<>();
+
+		//링크와 파일들 링크 얻고, 썸네일 처리
+        if (seed.getSeedType().equals(SeedType.LINK)) {
+            seedLink = files.get(0).getLink();
+        } else {
+			int idx = 0;
+			for(File file : files){
+				fileLinks.add(file.getLink());
+				titles.add(file.getFileName());
+				if(Boolean.TRUE.equals(file.getIsThumbnail())) {
+					thumbnailImage = (long) idx;
+				}
+				idx++;
+			}
+        }
+
+		//카테고리
+		List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
+		//태그
+		List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
+
+		return SeedResponse.SeedDetail.builder()
+				.seedId(seed.getId())
+				.seedType(seed.getSeedType())
+				.seedName(seed.getSeedName())
+				.seedLink(seedLink)
+				.fileLinks(fileLinks)
+				.titles(titles)
+				.thumbnailImage(thumbnailImage)
+				.categoryNames(categoryNames)
+				.tagNames(tagNames)
+				.dDay(seed.getDDay())
+				.seedDetail(seed.getSeedDetail())
+				.build();
 	}
 
 	private Seed saveSeed(SeedRequest seedRequest, Member member) {


### PR DESCRIPTION
## 🪺 Summary
씨드 상세보기 기능 리팩토링 완료했습니다!

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #121


## 🙏 To Reviewers
파일 저장할때
<img width="329" alt="image" src="https://github.com/user-attachments/assets/46f4b29f-5225-40e0-9c60-2573711be74d" />
이렇게 File의 file_name이랑 is_Thumnail이 계속 null로 저장됩니다!
