### PR TITLE
Refactor/custom filter 관련 리팩토링 #121

### DIFF
--- a/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
+++ b/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
@@ -55,15 +55,15 @@ public class FilterController {
 
 	@GetMapping("/{filterId}")
 	@Operation(summary = "필터를 통한 컨텐츠 조회 API", description = "필터를 통해 컨텐츠를 조회하는 API입니다.")
-	public ApiResponse<SeedResponse.GetAllSeeds> getContentsByFilter(
+	public ApiResponse<SeedResponse.GetFilteredSeeds> getContentsByFilter(
 		@RequestParam(defaultValue = "0") int page,
 		@RequestParam(defaultValue = "9") int size,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable Long filterId)
 	{
 
-		SeedResponse.GetAllSeeds customFilterSeeds = seedService.getCustomFilterSeeds(customUserDetails.getMember(),
-			page, size, filterId);
+		SeedResponse.GetFilteredSeeds customFilterSeeds = seedService.getCustomFilterSeeds(
+			customUserDetails.getMember(), page, size, filterId);
 
 		return new ApiResponse<>(customFilterSeeds);
 	}

--- a/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
+++ b/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
@@ -51,12 +51,19 @@ public class FilterController {
 
 	@GetMapping("/{filterId}")
 	@Operation(summary = "필터를 통한 컨텐츠 조회 API", description = "필터를 통해 컨텐츠를 조회하는 API입니다.")
-	public ApiResponse<ContentsAllResponse.contentsInfo> getContentsByFilter(
+	public ApiResponse<ContentsAllResponse.getAllContents> getContentsByFilter(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable Long filterId)
 	{
-		return new ApiResponse<>(contentsService.getCustomFilterContents(
-			customUserDetails.getMember(), filterId));
+		List<ContentsAllResponse.contentsInfo> customFilterContents = contentsService.getCustomFilterContents(
+			customUserDetails.getMember(), filterId);
+
+		ContentsAllResponse.getAllContents contents = ContentsAllResponse.getAllContents
+			.builder()
+			.contentsInfoList(customFilterContents)
+			.nickname(customUserDetails.getUsername())
+			.build();
+		return new ApiResponse<>(contents);
 	}
 
 	@GetMapping

--- a/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
+++ b/src/main/java/com/adoonge/seedzip/filter/controller/FilterController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.adoonge.seedzip.auth.util.CustomUserDetails;
@@ -23,6 +24,9 @@ import com.adoonge.seedzip.filter.dto.request.UpdateFilterNameRequest;
 import com.adoonge.seedzip.filter.service.FilterService;
 import com.adoonge.seedzip.global.dto.response.ApiResponse;
 import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.dto.response.SeedResponse;
+import com.adoonge.seedzip.seed.service.SeedService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -36,7 +40,7 @@ import lombok.RequiredArgsConstructor;
 public class FilterController {
 
 	private final FilterService filterService;
-	private final ContentsService contentsService;
+	private final SeedService seedService;
 
 	@PostMapping
 	@Operation(summary = "필터 생성 API", description = "필터 생성 API입니다.")
@@ -51,19 +55,17 @@ public class FilterController {
 
 	@GetMapping("/{filterId}")
 	@Operation(summary = "필터를 통한 컨텐츠 조회 API", description = "필터를 통해 컨텐츠를 조회하는 API입니다.")
-	public ApiResponse<ContentsAllResponse.getAllContents> getContentsByFilter(
+	public ApiResponse<SeedResponse.GetAllSeeds> getContentsByFilter(
+		@RequestParam(defaultValue = "0") int page,
+		@RequestParam(defaultValue = "9") int size,
 		@AuthenticationPrincipal CustomUserDetails customUserDetails,
 		@PathVariable Long filterId)
 	{
-		List<ContentsAllResponse.contentsInfo> customFilterContents = contentsService.getCustomFilterContents(
-			customUserDetails.getMember(), filterId);
 
-		ContentsAllResponse.getAllContents contents = ContentsAllResponse.getAllContents
-			.builder()
-			.contentsInfoList(customFilterContents)
-			.nickname(customUserDetails.getUsername())
-			.build();
-		return new ApiResponse<>(contents);
+		SeedResponse.GetAllSeeds customFilterSeeds = seedService.getCustomFilterSeeds(customUserDetails.getMember(),
+			page, size, filterId);
+
+		return new ApiResponse<>(customFilterSeeds);
 	}
 
 	@GetMapping

--- a/src/main/java/com/adoonge/seedzip/filter/repository/FilterRepositoryCustom.java
+++ b/src/main/java/com/adoonge/seedzip/filter/repository/FilterRepositoryCustom.java
@@ -7,18 +7,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
 @Repository
-@RequiredArgsConstructor
-public class FilterRepositoryCustom {
-	private final JPAQueryFactory queryFactory;
-
-	public Long findNextNumber(){
-		QFilter filter = QFilter.filter;
-
-		Long maxNumber = queryFactory.select(filter.filterNum.max())
-				.from(filter)
-				.fetchOne();
-
-		// 필터가 없으면 1부터 시작
-		return maxNumber != null ? maxNumber + 1 : 1;
-	}
+public interface FilterRepositoryCustom {
+	Long findNextNumber();
 }

--- a/src/main/java/com/adoonge/seedzip/filter/repository/FilterRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/filter/repository/FilterRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.adoonge.seedzip.filter.repository;
+
+import com.adoonge.seedzip.filter.domain.QFilter;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FilterRepositoryImpl implements FilterRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	public Long findNextNumber(){
+		QFilter filter = QFilter.filter;
+
+		Long maxNumber = queryFactory.select(filter.filterNum.max())
+			.from(filter)
+			.fetchOne();
+
+		// 필터가 없으면 1부터 시작
+		return maxNumber != null ? maxNumber + 1 : 1;
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -88,6 +88,7 @@ public enum ErrorCode {
 
     // seed
     SEED_NOT_FOUND(HttpStatus.NOT_FOUND, "씨드를 찾을 수 없습니다."),
+    SEED_TYPE_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 씨드 형식입니다."),
 
 
     // tag

--- a/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
@@ -2,6 +2,9 @@ package com.adoonge.seedzip.seed.domain;
 
 import com.adoonge.seedzip.global.entity.BaseEntity;
 import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.domain.mapping.CategorySeed;
+import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -12,8 +15,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -53,4 +60,14 @@ public class Seed extends BaseEntity {
     @JoinColumn(name = "member_id")
     @OnDelete(action = OnDeleteAction.CASCADE) // Member 삭제 시 Content도 삭제
     private Member member;
+
+    @OneToMany(mappedBy = "seed", fetch = FetchType.LAZY)
+    private Set<File> files = new HashSet<>();
+
+    @OneToMany(mappedBy = "seed", fetch = FetchType.LAZY)
+    private Set<SeedTag> seedTags = new HashSet<>();
+
+    @OneToMany(mappedBy = "seed", fetch = FetchType.LAZY)
+    private Set<CategorySeed> categorySeeds = new HashSet<>();
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/projection/CategorySeedProjection.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/projection/CategorySeedProjection.java
@@ -1,0 +1,7 @@
+package com.adoonge.seedzip.seed.dto.projection;
+
+public interface CategorySeedProjection {
+	Long getSeedId();
+	Long getCategoryId();
+	String getCategoryName();
+}

--- a/src/main/java/com/adoonge/seedzip/seed/dto/projection/FileSeedProjection.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/projection/FileSeedProjection.java
@@ -1,0 +1,10 @@
+package com.adoonge.seedzip.seed.dto.projection;
+
+import com.adoonge.seedzip.seed.domain.SeedType;
+
+public interface FileSeedProjection {
+	Long getSeedId();
+	SeedType getSeedType();
+	String getLink();
+	Boolean getIsThumbnail();
+}

--- a/src/main/java/com/adoonge/seedzip/seed/dto/projection/SeedTagProjection.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/projection/SeedTagProjection.java
@@ -1,0 +1,7 @@
+package com.adoonge.seedzip.seed.dto.projection;
+
+public interface SeedTagProjection {
+	Long getSeedId();
+	Long getTagId();
+	String getTagName();
+}

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -18,4 +18,6 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
 
     @Query("SELECT cs.seed.id FROM CategorySeed cs WHERE cs.category.categoryId = :categoryId")
     List<Long> findSeedIdsByCategoryId(@Param("categoryId") Long categoryId);
+
+    List<CategorySeed> findAllBySeedIdIn(List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -2,6 +2,8 @@ package com.adoonge.seedzip.seed.repository;
 
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.mapping.CategorySeed;
+import com.adoonge.seedzip.seed.dto.projection.CategorySeedProjection;
+
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -19,5 +21,7 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
     @Query("SELECT cs.seed.id FROM CategorySeed cs WHERE cs.category.categoryId = :categoryId")
     List<Long> findSeedIdsByCategoryId(@Param("categoryId") Long categoryId);
 
-    List<CategorySeed> findAllBySeedIdIn(List<Long> seedIds);
+    @Query("SELECT cs.seed.id as seedId, cs.category.categoryId as categoryId, cs.category.name as categoryName " +
+        "FROM CategorySeed cs WHERE cs.seed.id IN :seedIds")
+    List<CategorySeedProjection> findCategoryInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -16,4 +16,6 @@ public interface FileRepository extends JpaRepository<File, Long> {
     Optional<File> findBySeed(Seed seed);
 
     Optional<List<File>> findAllBySeed(Seed seed);
+
+    List<File> findAllBySeedIdIn(List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -2,6 +2,8 @@ package com.adoonge.seedzip.seed.repository;
 
 import com.adoonge.seedzip.seed.domain.File;
 import com.adoonge.seedzip.seed.domain.Seed;
+import com.adoonge.seedzip.seed.dto.projection.FileSeedProjection;
+
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,5 +19,7 @@ public interface FileRepository extends JpaRepository<File, Long> {
 
     Optional<List<File>> findAllBySeed(Seed seed);
 
-    List<File> findAllBySeedIdIn(List<Long> seedIds);
+    @Query("SELECT f.seed.id AS seedId, f.seed.seedType AS seedType, f.link AS link, f.isThumbnail AS isThumbnail " +
+        "FROM File f WHERE f.seed.id IN :seedIds")
+    List<FileSeedProjection> findFileInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
@@ -1,5 +1,9 @@
 package com.adoonge.seedzip.seed.repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
+import com.adoonge.seedzip.content.domain.Contents;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
@@ -12,4 +16,8 @@ import org.springframework.stereotype.Repository;
 public interface SeedRepositoryCustom {
     Page<Seed> findSeedsByFiltering(Member member, Pageable pageable, SeedType seedType, SeedFilteringRequest request);
     Page<Seed> findCategorySeedsByFiltering(Member member, Pageable pageable, SeedType seedType,Long categoryId ,SeedFilteringRequest request);
+    Page<Seed> findSeedsByCustomFilter(Pageable pageable, LocalDate startDate, LocalDate endDate,
+        List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberId
+    );
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -118,24 +118,32 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
         condition = safeAnd(condition, filterByTags(filterId));
 
         // 1. 페이징 대상 Seed ID 조회
-        List<Long> seedIds = queryFactory
-            .select(seed.id)
-            .from(seed)
+        // List<Long> seedIds = queryFactory
+        //     .select(seed.id)
+        //     .from(seed)
+        //     .where(condition)
+        //     .offset(pageable.getOffset())
+        //     .limit(pageable.getPageSize())
+        //     .fetch();
+        //
+        // // 2. 실제 Seed + 연관 데이터 조회 fetch join
+        // List<Seed> seeds = queryFactory
+        //     .selectDistinct(seed)
+        //     .from(seed)
+        //     .leftJoin(seed.files, file).fetchJoin()
+        //     .leftJoin(seed.seedTags, seedTag).fetchJoin()
+        //     .leftJoin(seedTag.tag, tag).fetchJoin()
+        //     .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
+        //     .leftJoin(categorySeed.category, category).fetchJoin()
+        //     .where(seed.id.in(seedIds))
+        //     .fetch();
+
+        // 기존: fetch join으로 모든 걸 한 번에 가져옴 → 제거
+        List<Seed> seeds = queryFactory
+            .selectFrom(seed)
             .where(condition)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())
-            .fetch();
-
-        // 2. 실제 Seed + 연관 데이터 조회 fetch join
-        List<Seed> seeds = queryFactory
-            .selectDistinct(seed)
-            .from(seed)
-            .leftJoin(seed.files, file).fetchJoin()
-            .leftJoin(seed.seedTags, seedTag).fetchJoin()
-            .leftJoin(seedTag.tag, tag).fetchJoin()
-            .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
-            .leftJoin(categorySeed.category, category).fetchJoin()
-            .where(seed.id.in(seedIds))
             .fetch();
 
         Long total = queryFactory

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -1,11 +1,13 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.category.domain.QCategory;
 import com.adoonge.seedzip.content.domain.Contents;
 import com.adoonge.seedzip.content.domain.ContentsDataType;
 import com.adoonge.seedzip.content.domain.QContents;
 import com.adoonge.seedzip.content.domain.mapping.QContentTag;
 import com.adoonge.seedzip.filter.domain.QFilterTag;
 import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.domain.QFile;
 import com.adoonge.seedzip.seed.domain.QSeed;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
@@ -42,6 +44,8 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
     QTag tag = QTag.tag;
     QCategorySeed categorySeed = QCategorySeed.categorySeed;
     QFilterTag filterTag = QFilterTag.filterTag;
+    QFile file = QFile.file;
+    QCategory category = QCategory.category;
 
     @Override
     public Page<Seed> findSeedsByFiltering(Member member, Pageable pageable, SeedType seedType, SeedFilteringRequest request) {
@@ -112,7 +116,13 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
         condition = safeAnd(condition, filterByTags(filterId));
 
         List<Seed> seeds = queryFactory
-            .selectFrom(seed)
+            .selectDistinct(seed)
+            .from(seed)
+            .leftJoin(seed.files, file).fetchJoin()
+            .leftJoin(seed.seedTags, seedTag).fetchJoin()
+            .leftJoin(seedTag.tag, tag).fetchJoin()
+            .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
+            .leftJoin(categorySeed.category, category).fetchJoin()
             .where(condition)
             .offset(pageable.getOffset())
             .limit(pageable.getPageSize())

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -189,18 +189,23 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
 
     // 저장 형식 필터 조건
     private BooleanExpression filterByStorageFormat(List<String> seedType) {
-
-        if (seedType != null ) {
-            BooleanExpression expression = null;
-
-            for (SeedType storageFormat : SeedType.values()) {
-                BooleanExpression condition = seed.seedType.eq(storageFormat);
-                expression = (expression == null) ? condition : expression.or(condition);
-            }
-
-            return expression;
+        if (seedType == null || seedType.isEmpty()) {
+            return null;
         }
-        return null; // 필터 조건이 없으면 null 반환
+
+        BooleanExpression expression = null;
+
+        for (String typeStr : seedType) {
+            try {
+                SeedType type = SeedType.valueOf(typeStr);
+                BooleanExpression condition = seed.seedType.eq(type);
+                expression = (expression == null) ? condition : expression.or(condition);
+            } catch (IllegalArgumentException e) {
+                System.out.println("Invalid seedType: " + typeStr);
+            }
+        }
+
+        return expression;
     }
 
     // D-Day 필터 조건

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -115,6 +115,16 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
         condition = safeAnd(condition, filterByStorageFormat(seedType));
         condition = safeAnd(condition, filterByTags(filterId));
 
+        // 1. 페이징 대상 Seed ID 조회
+        List<Long> seedIds = queryFactory
+            .select(seed.id)
+            .from(seed)
+            .where(condition)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        // 2. 실제 Seed + 연관 데이터 조회 fetch join
         List<Seed> seeds = queryFactory
             .selectDistinct(seed)
             .from(seed)
@@ -123,9 +133,7 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
             .leftJoin(seedTag.tag, tag).fetchJoin()
             .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
             .leftJoin(categorySeed.category, category).fetchJoin()
-            .where(condition)
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
+            .where(seed.id.in(seedIds))
             .fetch();
 
         Long total = queryFactory

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -1,5 +1,10 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.content.domain.Contents;
+import com.adoonge.seedzip.content.domain.ContentsDataType;
+import com.adoonge.seedzip.content.domain.QContents;
+import com.adoonge.seedzip.content.domain.mapping.QContentTag;
+import com.adoonge.seedzip.filter.domain.QFilterTag;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.QSeed;
 import com.adoonge.seedzip.seed.domain.Seed;
@@ -11,7 +16,12 @@ import com.adoonge.seedzip.tag.domain.QTag;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimePath;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +41,7 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
     QSeedTag seedTag = QSeedTag.seedTag;
     QTag tag = QTag.tag;
     QCategorySeed categorySeed = QCategorySeed.categorySeed;
+    QFilterTag filterTag = QFilterTag.filterTag;
 
     @Override
     public Page<Seed> findSeedsByFiltering(Member member, Pageable pageable, SeedType seedType, SeedFilteringRequest request) {
@@ -90,6 +101,32 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
         return new PageImpl<>(content, pageable, total != null ? total : 0);
     }
 
+    @Override
+    public Page<Seed> findSeedsByCustomFilter(Pageable pageable, LocalDate startDate, LocalDate endDate,
+        List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberID) {
+
+        BooleanExpression condition = seed.member.id.eq(memberID);
+        condition = safeAnd(condition, filterByDate(startDate, endDate));
+        condition = safeAnd(condition, filterByDDay(dDayStart, dDayEnd));
+        condition = safeAnd(condition, filterByStorageFormat(seedType));
+        condition = safeAnd(condition, filterByTags(filterId));
+
+        List<Seed> seeds = queryFactory
+            .selectFrom(seed)
+            .where(condition)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .fetch();
+
+        Long total = queryFactory
+            .select(seed.count())
+            .from(seed)
+            .where(condition)
+            .fetchOne();
+
+        return new PageImpl<>(seeds, pageable, total != null ? total : 0);
+    }
+
     //Category 필터 조건
     private BooleanExpression filteringByCategory(Long categoryId) {
         if(categoryId == null) {
@@ -131,6 +168,86 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
     //Keyword 필터 조건
     private BooleanExpression filteringByKeyword(String keyword) {
         return keyword != null && !keyword.isEmpty() ? seed.seedName.containsIgnoreCase(keyword).or(seed.seedDetail.containsIgnoreCase(keyword)) : null;
+    }
+
+    // 날짜 필터 조건
+    private BooleanExpression filterByDate(LocalDate startDate, LocalDate endDate) {
+        DateTimePath<LocalDateTime> createdAt = seed.createdAt;
+
+        if (startDate != null && endDate != null) {
+            if(startDate.equals(endDate)) {
+                return createdAt.between(startDate.atStartOfDay(), startDate.atStartOfDay().plusDays(1));
+            }
+            return createdAt.between(startDate.atStartOfDay(), endDate.atStartOfDay());
+        } else if (startDate != null) {
+            return createdAt.goe(startDate.atStartOfDay());
+        } else if (endDate != null) {
+            return createdAt.loe(endDate.atStartOfDay());
+        }
+        return null; // 조건이 없으면 null 반환
+    }
+
+    // 저장 형식 필터 조건
+    private BooleanExpression filterByStorageFormat(List<String> seedType) {
+
+        if (seedType != null ) {
+            BooleanExpression expression = null;
+
+            for (SeedType storageFormat : SeedType.values()) {
+                BooleanExpression condition = seed.seedType.eq(storageFormat);
+                expression = (expression == null) ? condition : expression.or(condition);
+            }
+
+            return expression;
+        }
+        return null; // 필터 조건이 없으면 null 반환
+    }
+
+    // D-Day 필터 조건
+    private BooleanExpression filterByDDay(Long fromDDay, Long toDDay) {
+
+        if (fromDDay != null && toDDay != null) {
+            if(fromDDay.equals(toDDay)) {	// D-Day가 같은 경우
+                return seed.dDay.eq(LocalDate.now().plusDays(fromDDay));
+            }
+            return seed.dDay.between(LocalDate.now().plusDays(fromDDay), LocalDate.now().plusDays(toDDay));
+        } else if (fromDDay != null) {
+            return seed.dDay.goe(LocalDate.now().plusDays(fromDDay));	// D-Day 시작 범위
+        } else if (toDDay != null) {
+            return seed.dDay.loe(LocalDate.now().plusDays(toDDay));	// D-Day 끝 범위
+        }
+        return null;
+    }
+
+    // 태그 필터 조건
+    private BooleanExpression filterByTags(Long filterId) {
+
+        if (filterId != null) {
+            // 필터에 해당하는 태그 ID 조회
+            List<Long> tagIds = queryFactory.select(filterTag.tag.id)
+                .from(filterTag)
+                .where(filterTag.filter.filterId.eq(filterId))
+                .fetch();
+
+            // 필터에 태그가 없으면 null 반환
+            if(tagIds.isEmpty()) {
+                return null;
+            }
+
+            // 콘텐츠에 필터 태그가 모두 포함되어야 함
+            return seed.id.in(
+                queryFactory
+                    .select(seedTag.seed.id)
+                    .from(seedTag)
+                    .where(seedTag.tag.id.in(tagIds))
+                    .groupBy(seedTag.seed.id)
+                    .having(
+                        Expressions.asNumber(seedTag.tag.id.countDistinct()) // 콘텐츠에 있는 태그의 개수
+                            .eq((long) tagIds.size()) // 필터 태그 개수만큼 태그가 있어야 함
+                    )
+            );
+        } else
+            return null;
     }
 
     // 정렬 조건 변환

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.adoonge.seedzip.content.domain.ContentsDataType;
 import com.adoonge.seedzip.content.domain.QContents;
 import com.adoonge.seedzip.content.domain.mapping.QContentTag;
 import com.adoonge.seedzip.filter.domain.QFilterTag;
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.QFile;
 import com.adoonge.seedzip.seed.domain.QSeed;
@@ -219,7 +221,7 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
                 BooleanExpression condition = seed.seedType.eq(type);
                 expression = (expression == null) ? condition : expression.or(condition);
             } catch (IllegalArgumentException e) {
-                System.out.println("Invalid seedType: " + typeStr);
+                throw SeedzipException.from(ErrorCode.SEED_TYPE_NOT_SUPPORTED);
             }
         }
 

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -224,35 +224,27 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
         return null;
     }
 
-    // 태그 필터 조건
     private BooleanExpression filterByTags(Long filterId) {
+        if (filterId == null) return null;
 
-        if (filterId != null) {
-            // 필터에 해당하는 태그 ID 조회
-            List<Long> tagIds = queryFactory.select(filterTag.tag.id)
-                .from(filterTag)
-                .where(filterTag.filter.filterId.eq(filterId))
-                .fetch();
+        // 1. 필터에 포함된 태그 ID 리스트 조회
+        List<Long> tagIds = queryFactory
+            .select(filterTag.tag.id)
+            .from(filterTag)
+            .where(filterTag.filter.filterId.eq(filterId))
+            .fetch();
 
-            // 필터에 태그가 없으면 null 반환
-            if(tagIds.isEmpty()) {
-                return null;
-            }
+        if (tagIds.isEmpty()) return null;
 
-            // 콘텐츠에 필터 태그가 모두 포함되어야 함
-            return seed.id.in(
-                queryFactory
-                    .select(seedTag.seed.id)
-                    .from(seedTag)
-                    .where(seedTag.tag.id.in(tagIds))
-                    .groupBy(seedTag.seed.id)
-                    .having(
-                        Expressions.asNumber(seedTag.tag.id.countDistinct()) // 콘텐츠에 있는 태그의 개수
-                            .eq((long) tagIds.size()) // 필터 태그 개수만큼 태그가 있어야 함
-                    )
-            );
-        } else
-            return null;
+        // 2. seedTag를 inner join하여 해당 태그들을 모두 포함하는 Seed만 조회
+        return seed.id.in(
+            queryFactory
+                .selectDistinct(seedTag.seed.id)
+                .from(seedTag)
+                .where(seedTag.tag.id.in(tagIds))
+                .groupBy(seedTag.seed.id)
+                .having(seedTag.tag.id.countDistinct().goe((long) tagIds.size()))
+        );
     }
 
     // 정렬 조건 변환

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -2,6 +2,8 @@ package com.adoonge.seedzip.seed.repository;
 
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
+import com.adoonge.seedzip.seed.dto.projection.SeedTagProjection;
+
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,5 +18,7 @@ public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
     @Query("SELECT st.tag.tagName FROM SeedTag st WHERE st.seed = :seed")
     List<String> findTagNamesBySeed(@Param("seed") Seed seed);
 
-    List<SeedTag> findAllBySeedIdIn(List<Long> seedIds);
+    @Query("SELECT st.seed.id as seedId, st.tag.id as tagId, st.tag.tagName as tagName " +
+        "FROM SeedTag st WHERE st.seed.id IN :seedIds")
+    List<SeedTagProjection> findTagInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -15,4 +15,6 @@ public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
     // 자동으로 Inner 조인 사용 , n+1 문제 발생 X
     @Query("SELECT st.tag.tagName FROM SeedTag st WHERE st.seed = :seed")
     List<String> findTagNamesBySeed(@Param("seed") Seed seed);
+
+    List<SeedTag> findAllBySeedIdIn(List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -499,6 +499,68 @@ public class SeedService {
 				.collect(Collectors.toList());
 	}
 
+	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact
+	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedListRefact(List<Seed> seedList) {
+		return seedList.stream()
+			.map(seed -> {
+				String thumbnailUrl = null;
+				//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
+				if (seed.getSeedType().equals(SeedType.LINK)) {
+					thumbnailUrl = seed.getFiles().stream()
+						.map(File::getLink)
+						.findFirst()
+						.orElse(null);
+				} else {
+					// 썸네일로 지정된 파일만 필터
+					thumbnailUrl = seed.getFiles().stream()
+						.filter(f -> Boolean.TRUE.equals(f.getIsThumbnail()))
+						.map(File::getLink)
+						.findFirst()
+						.orElse(null);
+				}
+
+				//seedId에 해당하는 카테고리 리스트 조회
+				List<Long> categoryIds = seed.getCategorySeeds().stream()
+					.map(cs -> cs.getCategory().getCategoryId())
+					.toList();
+				List<String> categoryNames = seed.getCategorySeeds().stream()
+					.map(cs -> cs.getCategory().getName())
+					.toList();
+
+				//seedId에 해당하는 태그 리스트 조회
+				List<Long> tagIds = seed.getSeedTags().stream()
+					.map(st -> st.getTag().getId())
+					.toList();
+				List<String> tagNames = seed.getSeedTags().stream()
+					.map(st -> st.getTag().getTagName())
+					.toList();
+
+				// D-day 계산
+				int dDayValue = 1;
+				if (seed.getDDay() != null) {
+					long daysBetween = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
+					dDayValue = (int) -daysBetween;
+				}
+
+				// SeedResponse 객체에 필요한 정보 담기
+				return new SeedResponse.SeedInfoWithSeedDetail(
+					seed.getId(),
+					seed.getSeedName(),
+					categoryIds,
+					categoryNames,
+					seed.getSeedType(),
+					thumbnailUrl,
+					seed.getUpdatedAt(),
+					tagIds,
+					tagNames,
+					dDayValue,
+					seed.getSeedDetail()
+				);
+
+			})
+			.collect(Collectors.toList());
+	}
+
 
 
 	// 정렬 방향을 결정하는 메소드
@@ -528,7 +590,7 @@ public class SeedService {
 		return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
 	}
 
-	public SeedResponse.GetAllSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
+	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
 
 		Filter filter = filterRepository.findById(filterId)
 			.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));
@@ -545,7 +607,8 @@ public class SeedService {
 		if (seedList.isEmpty())
 			return null;
 
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedListRefact(
+			seedList.getContent());
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -556,9 +619,9 @@ public class SeedService {
 			.isLast(seedList.isLast())
 			.build();
 
-		return SeedResponse.GetAllSeeds.builder()
+		return SeedResponse.GetFilteredSeeds.builder()
 			.nickname(member.getNickname())
-			.seedInfoList(seedInfoList)
+			.seedInfoList(seedInfoWithSeedDetails)
 			.pageInfo(pageInfo)
 			.build();
 	}

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,6 +1,10 @@
 package com.adoonge.seedzip.seed.service;
 
 import com.adoonge.seedzip.category.repository.CategoryRepository;
+import com.adoonge.seedzip.content.domain.Contents;
+import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
+import com.adoonge.seedzip.filter.domain.Filter;
+import com.adoonge.seedzip.filter.repository.FilterRepository;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
 import com.adoonge.seedzip.member.domain.Member;
@@ -60,6 +64,7 @@ public class SeedService {
 	private final UsedDefaultTagRepository usedDefaultTagRepository;
 	private final CategoryRepository categoryRepository;
 	private final SeedRepositoryCustom seedRepositoryCustom;
+	private final FilterRepository filterRepository;
 
 	private static final Set<String> DEFAULT_TAG_NAMES = Arrays.stream(DefaultTagType.values())
 		.map(DefaultTagType::getDisplayName)
@@ -521,5 +526,40 @@ public class SeedService {
 			}
 		}
 		return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
+	}
+
+	public SeedResponse.GetAllSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
+
+		Filter filter = filterRepository.findById(filterId)
+			.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));
+
+		if (!filter.getMember().getId().equals(member.getId())) {
+			throw SeedzipException.from(ErrorCode.FILTER_ACCESS_DENIED);
+		}
+
+		//페이징을 위한 Pageable 객체
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Seed> seedList = seedRepositoryCustom.findSeedsByCustomFilter(pageable, filter.getStartDate(), filter.getEndDate(),
+		filter.getStorageFormats(), filter.getFromDDay(), filter.getToDDay(), filter.getFilterId(), member.getId());
+
+		if (seedList.isEmpty())
+			return null;
+
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+
+		//페이징 정보 추가
+		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+			.page(seedList.getNumber())
+			.size(seedList.getSize())
+			.totalPages(seedList.getTotalPages())
+			.totalElements(seedList.getTotalElements())
+			.isLast(seedList.isLast())
+			.build();
+
+		return SeedResponse.GetAllSeeds.builder()
+			.nickname(member.getNickname())
+			.seedInfoList(seedInfoList)
+			.pageInfo(pageInfo)
+			.build();
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -33,6 +33,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -442,104 +443,42 @@ public class SeedService {
 	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환
 	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedList(List<Seed> seedList) {
 		return seedList.stream()
-				.map(seed -> {
-					String thumbnailUrl = null;
-					//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
-					if (seed.getSeedType().equals(SeedType.LINK)) {
-						Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
-						if (thumbnailFile.isPresent()) {
-							thumbnailUrl = thumbnailFile.get().getLink();
-						}
-					}
-					// 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
-					else {
-						Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
-						if (thumbnailFile.isPresent()) {
-							thumbnailUrl = thumbnailFile.get().getLink();
-						}
-					}
-
-					//seedId에 해당하는 카테고리 리스트 조회
-					List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
-					List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
-
-					//seedId에 해당하는 태그 리스트 조회
-					List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
-					List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
-
-					// D-day 계산
-					int dDayValue = 1;
-					if (seed.getDDay() != null) {
-						LocalDate today = LocalDate.now();
-						long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
-
-						if (daysBetween > 0) {
-							dDayValue = -(int)daysBetween;
-						} else if (daysBetween == 0) {
-							dDayValue = 0;
-						}
-					}
-
-					// SeedResponse 객체에 필요한 정보 담기
-					return new SeedResponse.SeedInfoWithSeedDetail(
-							seed.getId(),
-							seed.getSeedName(),
-							categoryIds,
-							categoryNames,
-							seed.getSeedType(),
-							thumbnailUrl,
-							seed.getUpdatedAt(),
-							tagIds,
-							tagNames,
-							dDayValue,
-							seed.getSeedDetail()
-					);
-
-				})
-				.collect(Collectors.toList());
-	}
-
-	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact
-	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedListRefact(List<Seed> seedList) {
-		return seedList.stream()
 			.map(seed -> {
 				String thumbnailUrl = null;
 				//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
 				if (seed.getSeedType().equals(SeedType.LINK)) {
-					thumbnailUrl = seed.getFiles().stream()
-						.map(File::getLink)
-						.findFirst()
-						.orElse(null);
-				} else {
-					// 썸네일로 지정된 파일만 필터
-					thumbnailUrl = seed.getFiles().stream()
-						.filter(f -> Boolean.TRUE.equals(f.getIsThumbnail()))
-						.map(File::getLink)
-						.findFirst()
-						.orElse(null);
+					Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
+					if (thumbnailFile.isPresent()) {
+						thumbnailUrl = thumbnailFile.get().getLink();
+					}
+				}
+				// 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
+				else {
+					Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
+					if (thumbnailFile.isPresent()) {
+						thumbnailUrl = thumbnailFile.get().getLink();
+					}
 				}
 
 				//seedId에 해당하는 카테고리 리스트 조회
-				List<Long> categoryIds = seed.getCategorySeeds().stream()
-					.map(cs -> cs.getCategory().getCategoryId())
-					.toList();
-				List<String> categoryNames = seed.getCategorySeeds().stream()
-					.map(cs -> cs.getCategory().getName())
-					.toList();
+				List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
+				List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
 
 				//seedId에 해당하는 태그 리스트 조회
-				List<Long> tagIds = seed.getSeedTags().stream()
-					.map(st -> st.getTag().getId())
-					.toList();
-				List<String> tagNames = seed.getSeedTags().stream()
-					.map(st -> st.getTag().getTagName())
-					.toList();
+				List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
+				List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
 
 				// D-day 계산
 				int dDayValue = 1;
 				if (seed.getDDay() != null) {
-					long daysBetween = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
-					dDayValue = (int) -daysBetween;
+					LocalDate today = LocalDate.now();
+					long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
+
+					if (daysBetween > 0) {
+						dDayValue = -(int)daysBetween;
+					} else if (daysBetween == 0) {
+						dDayValue = 0;
+					}
 				}
 
 				// SeedResponse 객체에 필요한 정보 담기
@@ -557,6 +496,78 @@ public class SeedService {
 					seed.getSeedDetail()
 				);
 
+			})
+			.collect(Collectors.toList());
+	}
+
+	// //List<Seed> -> List<SeedResponse.SeedInfo>로 변환
+	// private List<SeedResponse.SeedInfo> generateResponseFromSeedListRefact(
+	// 	List<Seed> seedList,
+	// 	Map<Long, String> thumbnailMap,
+	// 	Map<Long, List<Long>> categoryIdMap,
+	// 	Map<Long, List<String>> categoryNameMap,
+	// 	Map<Long, List<Long>> tagIdMap,
+	// 	Map<Long, List<String>> tagNameMap
+	// ) {
+	// 	return seedList.stream()
+	// 		.map(seed -> {
+	// 			Long seedId = seed.getId();
+	//
+	// 			int dDayValue = 1;
+	// 			if (seed.getDDay() != null) {
+	// 				long days = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
+	// 				dDayValue = days > 0 ? -(int) days : (days == 0 ? 0 : 1);
+	// 			}
+	//
+	// 			return new SeedResponse.SeedInfo(
+	// 				seedId,
+	// 				seed.getSeedName(),
+	// 				categoryIdMap.getOrDefault(seedId, List.of()),
+	// 				categoryNameMap.getOrDefault(seedId, List.of()),
+	// 				seed.getSeedType(),
+	// 				thumbnailMap.getOrDefault(seedId, null),
+	// 				seed.getUpdatedAt(),
+	// 				tagIdMap.getOrDefault(seedId, List.of()),
+	// 				tagNameMap.getOrDefault(seedId, List.of()),
+	// 				dDayValue
+	// 			);
+	// 		})
+	// 		.toList();
+	// }
+
+	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact
+	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedList(
+		List<Seed> seedList,
+		Map<Long, String> thumbnailMap,
+		Map<Long, List<Long>> categoryIdMap,
+		Map<Long, List<String>> categoryNameMap,
+		Map<Long, List<Long>> tagIdMap,
+		Map<Long, List<String>> tagNameMap
+	) {
+		return seedList.stream()
+			.map(seed -> {
+				Long seedId = seed.getId();
+
+				// D-day 계산
+				int dDayValue = 1;
+				if (seed.getDDay() != null) {
+					long days = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
+					dDayValue = days > 0 ? -(int) days : (days == 0 ? 0 : 1);
+				}
+
+				return new SeedResponse.SeedInfoWithSeedDetail(
+					seedId,
+					seed.getSeedName(),
+					categoryIdMap.getOrDefault(seedId, List.of()),
+					categoryNameMap.getOrDefault(seedId, List.of()),
+					seed.getSeedType(),
+					thumbnailMap.getOrDefault(seedId, null),
+					seed.getUpdatedAt(),
+					tagIdMap.getOrDefault(seedId, List.of()),
+					tagNameMap.getOrDefault(seedId, List.of()),
+					dDayValue,
+					seed.getSeedDetail()
+				);
 			})
 			.collect(Collectors.toList());
 	}
@@ -591,7 +602,6 @@ public class SeedService {
 	}
 
 	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
-
 		Filter filter = filterRepository.findById(filterId)
 			.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));
 
@@ -601,22 +611,63 @@ public class SeedService {
 
 		//페이징을 위한 Pageable 객체
 		Pageable pageable = PageRequest.of(page, size);
-		Page<Seed> seedList = seedRepositoryCustom.findSeedsByCustomFilter(pageable, filter.getStartDate(), filter.getEndDate(),
+		Page<Seed> seedPage = seedRepositoryCustom.findSeedsByCustomFilter(pageable, filter.getStartDate(), filter.getEndDate(),
 		filter.getStorageFormats(), filter.getFromDDay(), filter.getToDDay(), filter.getFilterId(), member.getId());
+		List<Seed> seedList = seedPage.getContent();
 
 		if (seedList.isEmpty())
 			return null;
 
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedListRefact(
-			seedList.getContent());
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+			.map(Seed::getId)
+			.toList();
 
-		//페이징 정보 추가
+		// 썸네일 파일
+		Map<Long, String> thumbnailMap = fileRepository.findAllBySeedIdIn(seedIds).stream()
+			.filter(file -> {
+				SeedType type = file.getSeed().getSeedType();
+				Boolean isThumb = file.getIsThumbnail();
+
+				// LINK: 어떤 파일이든 썸네일로 사용
+				if (type == SeedType.LINK) return true;
+
+				// IMAGE, PDF: 썸네일이 true인 경우만 사용
+				return (type == SeedType.IMAGE || type == SeedType.PDF) && Boolean.TRUE.equals(isThumb);
+			})
+			.collect(Collectors.toMap(
+				file -> file.getSeed().getId(),
+				File::getLink,
+				(f1, f2) -> f1 // 여러 개일 경우 첫 번째 값 유지
+			));
+		// 카테고리
+		List<CategorySeed> categorySeeds = categorySeedRepository.findAllBySeedIdIn(seedIds);
+		Map<Long, List<Long>> categoryIdMap = categorySeeds.stream()
+			.collect(Collectors.groupingBy(cs -> cs.getSeed().getId(),
+				Collectors.mapping(cs -> cs.getCategory().getCategoryId(), Collectors.toList())));
+		Map<Long, List<String>> categoryNameMap = categorySeeds.stream()
+			.collect(Collectors.groupingBy(cs -> cs.getSeed().getId(),
+				Collectors.mapping(cs -> cs.getCategory().getName(), Collectors.toList())));
+
+		// 태그
+		List<SeedTag> seedTags = seedTagRepository.findAllBySeedIdIn(seedIds);
+		Map<Long, List<Long>> tagIdMap = seedTags.stream()
+			.collect(Collectors.groupingBy(st -> st.getSeed().getId(),
+				Collectors.mapping(st -> st.getTag().getId(), Collectors.toList())));
+		Map<Long, List<String>> tagNameMap = seedTags.stream()
+			.collect(Collectors.groupingBy(st -> st.getSeed().getId(),
+				Collectors.mapping(st -> st.getTag().getTagName(), Collectors.toList())));
+
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(
+			seedList, thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+
+
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-			.page(seedList.getNumber())
-			.size(seedList.getSize())
-			.totalPages(seedList.getTotalPages())
-			.totalElements(seedList.getTotalElements())
-			.isLast(seedList.isLast())
+			.page(seedPage.getNumber())
+			.size(seedPage.getSize())
+			.totalPages(seedPage.getTotalPages())
+			.totalElements(seedPage.getTotalElements())
+			.isLast(seedPage.isLast())
 			.build();
 
 		return SeedResponse.GetFilteredSeeds.builder()

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -14,6 +14,9 @@ import com.adoonge.seedzip.seed.domain.SeedType;
 import com.adoonge.seedzip.seed.domain.mapping.CategorySeed;
 import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
 import com.adoonge.seedzip.seed.dto.SeedDTO;
+import com.adoonge.seedzip.seed.dto.projection.CategorySeedProjection;
+import com.adoonge.seedzip.seed.dto.projection.FileSeedProjection;
+import com.adoonge.seedzip.seed.dto.projection.SeedTagProjection;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
@@ -500,41 +503,6 @@ public class SeedService {
 			.collect(Collectors.toList());
 	}
 
-	// //List<Seed> -> List<SeedResponse.SeedInfo>로 변환
-	// private List<SeedResponse.SeedInfo> generateResponseFromSeedListRefact(
-	// 	List<Seed> seedList,
-	// 	Map<Long, String> thumbnailMap,
-	// 	Map<Long, List<Long>> categoryIdMap,
-	// 	Map<Long, List<String>> categoryNameMap,
-	// 	Map<Long, List<Long>> tagIdMap,
-	// 	Map<Long, List<String>> tagNameMap
-	// ) {
-	// 	return seedList.stream()
-	// 		.map(seed -> {
-	// 			Long seedId = seed.getId();
-	//
-	// 			int dDayValue = 1;
-	// 			if (seed.getDDay() != null) {
-	// 				long days = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
-	// 				dDayValue = days > 0 ? -(int) days : (days == 0 ? 0 : 1);
-	// 			}
-	//
-	// 			return new SeedResponse.SeedInfo(
-	// 				seedId,
-	// 				seed.getSeedName(),
-	// 				categoryIdMap.getOrDefault(seedId, List.of()),
-	// 				categoryNameMap.getOrDefault(seedId, List.of()),
-	// 				seed.getSeedType(),
-	// 				thumbnailMap.getOrDefault(seedId, null),
-	// 				seed.getUpdatedAt(),
-	// 				tagIdMap.getOrDefault(seedId, List.of()),
-	// 				tagNameMap.getOrDefault(seedId, List.of()),
-	// 				dDayValue
-	// 			);
-	// 		})
-	// 		.toList();
-	// }
-
 	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact
 	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedList(
 		List<Seed> seedList,
@@ -623,40 +591,32 @@ public class SeedService {
 			.map(Seed::getId)
 			.toList();
 
-		// 썸네일 파일
-		Map<Long, String> thumbnailMap = fileRepository.findAllBySeedIdIn(seedIds).stream()
-			.filter(file -> {
-				SeedType type = file.getSeed().getSeedType();
-				Boolean isThumb = file.getIsThumbnail();
-
-				// LINK: 어떤 파일이든 썸네일로 사용
-				if (type == SeedType.LINK) return true;
-
-				// IMAGE, PDF: 썸네일이 true인 경우만 사용
-				return (type == SeedType.IMAGE || type == SeedType.PDF) && Boolean.TRUE.equals(isThumb);
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = fileProjections.stream()
+			.filter(p -> {
+				if (p.getSeedType() == SeedType.LINK) return true;
+				return Boolean.TRUE.equals(p.getIsThumbnail());
 			})
-			.collect(Collectors.toMap(
-				file -> file.getSeed().getId(),
-				File::getLink,
-				(f1, f2) -> f1 // 여러 개일 경우 첫 번째 값 유지
-			));
-		// 카테고리
-		List<CategorySeed> categorySeeds = categorySeedRepository.findAllBySeedIdIn(seedIds);
-		Map<Long, List<Long>> categoryIdMap = categorySeeds.stream()
-			.collect(Collectors.groupingBy(cs -> cs.getSeed().getId(),
-				Collectors.mapping(cs -> cs.getCategory().getCategoryId(), Collectors.toList())));
-		Map<Long, List<String>> categoryNameMap = categorySeeds.stream()
-			.collect(Collectors.groupingBy(cs -> cs.getSeed().getId(),
-				Collectors.mapping(cs -> cs.getCategory().getName(), Collectors.toList())));
+			.collect(Collectors.toMap(FileSeedProjection::getSeedId, FileSeedProjection::getLink, (f1, f2) -> f1));
 
-		// 태그
-		List<SeedTag> seedTags = seedTagRepository.findAllBySeedIdIn(seedIds);
-		Map<Long, List<Long>> tagIdMap = seedTags.stream()
-			.collect(Collectors.groupingBy(st -> st.getSeed().getId(),
-				Collectors.mapping(st -> st.getTag().getId(), Collectors.toList())));
-		Map<Long, List<String>> tagNameMap = seedTags.stream()
-			.collect(Collectors.groupingBy(st -> st.getSeed().getId(),
-				Collectors.mapping(st -> st.getTag().getTagName(), Collectors.toList())));
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = categoryProjections.stream()
+			.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
+				Collectors.mapping(CategorySeedProjection::getCategoryId, Collectors.toList())));
+		Map<Long, List<String>> categoryNameMap = categoryProjections.stream()
+			.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
+				Collectors.mapping(CategorySeedProjection::getCategoryName, Collectors.toList())));
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = tagProjections.stream()
+			.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
+				Collectors.mapping(SeedTagProjection::getTagId, Collectors.toList())));
+		Map<Long, List<String>> tagNameMap = tagProjections.stream()
+			.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
+				Collectors.mapping(SeedTagProjection::getTagName, Collectors.toList())));
 
 		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(
 			seedList, thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   # Spring Data JPA
   jpa:
-    show-sql: 'false'
+    show-sql: 'true'
     hibernate:
       ddl-auto: update
     open-in-view: 'false'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   # Spring Data JPA
   jpa:
-    show-sql: 'true'
+    show-sql: 'false'
     hibernate:
       ddl-auto: update
     open-in-view: 'false'


### PR DESCRIPTION
## 🪺 Summary
- Content -> Seed로 커스텀 필터 부분 이동 완료
- N+1 문제가 generateResponse하면서 생기는것 확인 -> seed마다 file, seed tag, category seed 를 조회 -> 결과값이 7개면 7번조회...
- fetchjoin, OneToMany, generate코드 변경 등으로 해결
노션에 조금 더 자세히 적어놓았습니다
https://cream-browser-e86.notion.site/Custom-Filter-N-1-1e5ef1476ee58068b2a4ebe64f285fe2?pvs=4


## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #121 


## 🙏 To Reviewers
- generate함수 Response로 옮기는거 어떨까요?
- 확인해보니 SeedController의 필터링 코드들도 generate 하면서 N+1 발생해가지고 한번 전체적으로 수정해야할 것 같아요! 
- 일단 generateResponseWithDetailFromSeedListRefact 이거만들어놨는데 애초에 조회할때 fetchjoin으로 받아오면 다시 레포접근안하고 seed에서 get할 수 있도록 변경한 구조입니다!