### PR TITLE
Refactor: 기존 조회 코드 DTO Projection 방식으로 리팩토링 완료 #121

### DIFF
--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -94,7 +94,26 @@ public class SeedService {
 		if (seedList.isEmpty())
 			return null;
 
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+				.map(Seed::getId)
+				.toList();
+
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -136,7 +155,26 @@ public class SeedService {
 		if (seedList.isEmpty())
 			return null;
 
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent());
+		// seedId 리스트 추출
+		seedIds = seedList.stream()
+				.map(Seed::getId)
+				.toList();
+
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -258,7 +296,27 @@ public class SeedService {
 			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
 		}
 
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent());
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+				.map(Seed::getId)
+				.toList();
+
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(
+				seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -298,7 +356,27 @@ public class SeedService {
 			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
 		}
 
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent());
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+				.map(Seed::getId)
+				.toList();
+
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(
+				seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -439,122 +517,38 @@ public class SeedService {
 	}
 
 	//List<Seed> -> List<SeedResponse.SeedInfo>로 변환
-	private List<SeedResponse.SeedInfo> generateResponseFromSeedList(List<Seed> seedList) {
+	private List<SeedResponse.SeedInfo> generateResponseFromSeedList(
+			List<Seed> seedList,
+			Map<Long, String> thumbnailMap,
+			Map<Long, List<Long>> categoryIdMap,
+			Map<Long, List<String>> categoryNameMap,
+			Map<Long, List<Long>> tagIdMap,
+			Map<Long, List<String>> tagNameMap) {
 		return seedList.stream()
-			.map(seed -> {
-				String thumbnailUrl = null;
-				//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
-				if (seed.getSeedType().equals(SeedType.LINK)) {
-					Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
-					if (thumbnailFile.isPresent()) {
-						thumbnailUrl = thumbnailFile.get().getLink();
+				.map(seed -> {
+					Long seedId = seed.getId();
+
+					// D-day 계산
+					int dDayValue = 1;
+					if (seed.getDDay() != null) {
+						long days = ChronoUnit.DAYS.between(LocalDate.now(), seed.getDDay());
+						dDayValue = days > 0 ? -(int) days : (days == 0 ? 0 : 1);
 					}
-				}
-				// 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
-				else {
-					Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
-					if (thumbnailFile.isPresent()) {
-						thumbnailUrl = thumbnailFile.get().getLink();
-					}
-				}
 
-				//seedId에 해당하는 카테고리 리스트 조회
-				List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
-				List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
-
-				//seedId에 해당하는 태그 리스트 조회
-				List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
-				List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
-
-				// D-day 계산
-				int dDayValue = 1;
-				if (seed.getDDay() != null) {
-					LocalDate today = LocalDate.now();
-					long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
-
-					if (daysBetween > 0) {
-						dDayValue = -(int)daysBetween;
-					} else if (daysBetween == 0) {
-						dDayValue = 0;
-					}
-				}
-
-				// SeedResponse 객체에 필요한 정보 담기
-				return new SeedResponse.SeedInfo(
-					seed.getId(),
-					seed.getSeedName(),
-					categoryIds,
-					categoryNames,
-					seed.getSeedType(),
-					thumbnailUrl,
-					seed.getUpdatedAt(),
-					tagIds,
-					tagNames,
-					dDayValue
-				);
-
-			})
-			.collect(Collectors.toList());
-	}
-
-	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환
-	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedList(List<Seed> seedList) {
-		return seedList.stream()
-			.map(seed -> {
-				String thumbnailUrl = null;
-				//링크의 경우 thumbnail 없으니까, 해당 링크를 thumbnailUrl로 처리
-				if (seed.getSeedType().equals(SeedType.LINK)) {
-					Optional<File> thumbnailFile = fileRepository.findBySeed(seed);
-					if (thumbnailFile.isPresent()) {
-						thumbnailUrl = thumbnailFile.get().getLink();
-					}
-				}
-				// 이미지, PDF의 경우 isThumbnail이 true인 파일만 가져와서 s3 링크 추출
-				else {
-					Optional<File> thumbnailFile = fileRepository.findThumbnailBySeed(seed);
-					if (thumbnailFile.isPresent()) {
-						thumbnailUrl = thumbnailFile.get().getLink();
-					}
-				}
-
-				//seedId에 해당하는 카테고리 리스트 조회
-				List<Long> categoryIds = categorySeedRepository.findCategoryIdsBySeed(seed);
-				List<String> categoryNames = categorySeedRepository.findCategoryNamesBySeed(seed);
-
-				//seedId에 해당하는 태그 리스트 조회
-				List<Long> tagIds = seedTagRepository.findTagIdsBySeed(seed);
-				List<String> tagNames = seedTagRepository.findTagNamesBySeed(seed);
-
-				// D-day 계산
-				int dDayValue = 1;
-				if (seed.getDDay() != null) {
-					LocalDate today = LocalDate.now();
-					long daysBetween = ChronoUnit.DAYS.between(today, seed.getDDay());
-
-					if (daysBetween > 0) {
-						dDayValue = -(int)daysBetween;
-					} else if (daysBetween == 0) {
-						dDayValue = 0;
-					}
-				}
-
-				// SeedResponse 객체에 필요한 정보 담기
-				return new SeedResponse.SeedInfoWithSeedDetail(
-					seed.getId(),
-					seed.getSeedName(),
-					categoryIds,
-					categoryNames,
-					seed.getSeedType(),
-					thumbnailUrl,
-					seed.getUpdatedAt(),
-					tagIds,
-					tagNames,
-					dDayValue,
-					seed.getSeedDetail()
-				);
-
-			})
-			.collect(Collectors.toList());
+					return new SeedResponse.SeedInfo(
+							seedId,
+							seed.getSeedName(),
+							categoryIdMap.getOrDefault(seedId, List.of()),
+							categoryNameMap.getOrDefault(seedId, List.of()),
+							seed.getSeedType(),
+							thumbnailMap.getOrDefault(seedId, null),
+							seed.getUpdatedAt(),
+							tagIdMap.getOrDefault(seedId, List.of()),
+							tagNameMap.getOrDefault(seedId, List.of()),
+							dDayValue
+					);
+				})
+				.collect(Collectors.toList());
 	}
 
 	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,8 +1,6 @@
 package com.adoonge.seedzip.seed.service;
 
 import com.adoonge.seedzip.category.repository.CategoryRepository;
-import com.adoonge.seedzip.content.domain.Contents;
-import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
 import com.adoonge.seedzip.filter.domain.Filter;
 import com.adoonge.seedzip.filter.repository.FilterRepository;
 import com.adoonge.seedzip.global.exception.ErrorCode;
@@ -318,6 +316,62 @@ public class SeedService {
 				.build();
 	}
 
+	@Transactional(readOnly = true)
+	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
+		Filter filter = filterRepository.findById(filterId)
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));
+
+		if (!filter.getMember().getId().equals(member.getId())) {
+			throw SeedzipException.from(ErrorCode.FILTER_ACCESS_DENIED);
+		}
+
+		//페이징을 위한 Pageable 객체
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Seed> seedPage = seedRepositoryCustom.findSeedsByCustomFilter(pageable, filter.getStartDate(), filter.getEndDate(),
+				filter.getStorageFormats(), filter.getFromDDay(), filter.getToDDay(), filter.getFilterId(), member.getId());
+		List<Seed> seedList = seedPage.getContent();
+
+		if (seedList.isEmpty())
+			return null;
+
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+				.map(Seed::getId)
+				.toList();
+
+		// 파일 프로젝션으로 썸네일 처리
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 projection
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 projection
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(
+				seedList, thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+
+
+		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+				.page(seedPage.getNumber())
+				.size(seedPage.getSize())
+				.totalPages(seedPage.getTotalPages())
+				.totalElements(seedPage.getTotalElements())
+				.isLast(seedPage.isLast())
+				.build();
+
+		return SeedResponse.GetFilteredSeeds.builder()
+				.nickname(member.getNickname())
+				.seedInfoList(seedInfoWithSeedDetails)
+				.pageInfo(pageInfo)
+				.build();
+	}
+
 	private Seed saveSeed(SeedRequest seedRequest, Member member) {
 		SeedDTO seedDTO = SeedDTO.builder()
 			.seedName(seedRequest.seedName() == null ? LocalDate.now().toString() : seedRequest.seedName())
@@ -540,8 +594,6 @@ public class SeedService {
 			.collect(Collectors.toList());
 	}
 
-
-
 	// 정렬 방향을 결정하는 메소드
 	private Sort.Direction getSortDirection(boolean isAsc) {
 		return isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
@@ -569,71 +621,38 @@ public class SeedService {
 		return null;  // seedType이 null 또는 빈 문자열일 경우 null 반환
 	}
 
-	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
-		Filter filter = filterRepository.findById(filterId)
-			.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));
 
-		if (!filter.getMember().getId().equals(member.getId())) {
-			throw SeedzipException.from(ErrorCode.FILTER_ACCESS_DENIED);
-		}
-
-		//페이징을 위한 Pageable 객체
-		Pageable pageable = PageRequest.of(page, size);
-		Page<Seed> seedPage = seedRepositoryCustom.findSeedsByCustomFilter(pageable, filter.getStartDate(), filter.getEndDate(),
-		filter.getStorageFormats(), filter.getFromDDay(), filter.getToDDay(), filter.getFilterId(), member.getId());
-		List<Seed> seedList = seedPage.getContent();
-
-		if (seedList.isEmpty())
-			return null;
-
-		// seedId 리스트 추출
-		List<Long> seedIds = seedList.stream()
-			.map(Seed::getId)
-			.toList();
-
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = fileProjections.stream()
-			.filter(p -> {
-				if (p.getSeedType() == SeedType.LINK) return true;
-				return Boolean.TRUE.equals(p.getIsThumbnail());
-			})
-			.collect(Collectors.toMap(FileSeedProjection::getSeedId, FileSeedProjection::getLink, (f1, f2) -> f1));
-
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = categoryProjections.stream()
-			.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
-				Collectors.mapping(CategorySeedProjection::getCategoryId, Collectors.toList())));
-		Map<Long, List<String>> categoryNameMap = categoryProjections.stream()
-			.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
-				Collectors.mapping(CategorySeedProjection::getCategoryName, Collectors.toList())));
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = tagProjections.stream()
-			.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
-				Collectors.mapping(SeedTagProjection::getTagId, Collectors.toList())));
-		Map<Long, List<String>> tagNameMap = tagProjections.stream()
-			.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
-				Collectors.mapping(SeedTagProjection::getTagName, Collectors.toList())));
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(
-			seedList, thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
-
-
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-			.page(seedPage.getNumber())
-			.size(seedPage.getSize())
-			.totalPages(seedPage.getTotalPages())
-			.totalElements(seedPage.getTotalElements())
-			.isLast(seedPage.isLast())
-			.build();
-
-		return SeedResponse.GetFilteredSeeds.builder()
-			.nickname(member.getNickname())
-			.seedInfoList(seedInfoWithSeedDetails)
-			.pageInfo(pageInfo)
-			.build();
+	private Map<Long, String> getThumbnailMap(List<FileSeedProjection> fileProjections) {
+		return fileProjections.stream()
+				.filter(p -> {
+					if (p.getSeedType() == SeedType.LINK) return true;
+					return Boolean.TRUE.equals(p.getIsThumbnail());
+				})
+				.collect(Collectors.toMap(FileSeedProjection::getSeedId, FileSeedProjection::getLink, (f1, f2) -> f1));
 	}
+
+	private Map<Long, List<Long>> getCategoryIdMap(List<CategorySeedProjection> categoryProjections) {
+		return categoryProjections.stream()
+				.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
+						Collectors.mapping(CategorySeedProjection::getCategoryId, Collectors.toList())));
+	}
+
+	private Map<Long, List<String>> getCategoryNameMap(List<CategorySeedProjection> categoryProjections) {
+		return categoryProjections.stream()
+				.collect(Collectors.groupingBy(CategorySeedProjection::getSeedId,
+						Collectors.mapping(CategorySeedProjection::getCategoryName, Collectors.toList())));
+	}
+
+	private Map<Long, List<Long>> getTagIdMap (List<SeedTagProjection> tagProjections) {
+		return tagProjections.stream()
+				.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
+						Collectors.mapping(SeedTagProjection::getTagId, Collectors.toList())));
+	}
+
+	private Map<Long, List<String>> getTagNameMap (List<SeedTagProjection> tagProjections) {
+		return tagProjections.stream()
+				.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
+						Collectors.mapping(SeedTagProjection::getTagName, Collectors.toList())));
+	}
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
 
   # Spring Data JPA
   jpa:
-    show-sql: 'true'
+    show-sql: 'false'
     hibernate:
       ddl-auto: update
     open-in-view: 'false'


### PR DESCRIPTION
## 🪺 Summary
중복되는 코드 메소드화 했고, 기존 제가 구현했던 조회 코드들 DTO Projection 방식 적용했습니다!

2번 카테고리 조회 (7개) 결과입니다!

리팩토링 전 카테고리 내 씨드 조회
<img width="135" alt="image" src="https://github.com/user-attachments/assets/ba6657aa-e888-45a9-9e2e-1acb70152f5a" />

리팩토링 후 카테고리 내 씨드 조회
<img width="141" alt="image" src="https://github.com/user-attachments/assets/b6963c54-741b-476c-8e04-b54297c4815d" />

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #121

## 🙏 To Reviewers
