### PR TITLE
Refactor : 씨드 수정 및 삭제 #131

### DIFF
--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     DUPLICATE_MEMBER_PHONE_NUMBER(HttpStatus.CONFLICT, "중복된 전화번호입니다"),
     PROFILE_IMAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "프로필 이미지를 찾을 수 없습니다"),
     MEMBER_NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자가 아닙니다"),
+    MEMBER_NOT_OWNER(HttpStatus.FORBIDDEN, "소유자가 아닙니다"),
 
     // auth
     MEMBER_JOIN_REQUIRED(HttpStatus.MULTIPLE_CHOICES, "회원가입이 필요합니다."),
@@ -44,6 +45,7 @@ public enum ErrorCode {
     S3_DOWNLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷에서 파일을 다운로드하는 중 에러가 발생했습니다."),
     S3_DELETE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷에서 파일을 삭제하는 중 에러가 발생했습니다."),
     MALFORMED_URL_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다."),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
 
 
     // others
@@ -93,6 +95,7 @@ public enum ErrorCode {
     // seed
     SEED_NOT_FOUND(HttpStatus.NOT_FOUND, "씨드를 찾을 수 없습니다."),
     SEED_TYPE_NOT_SUPPORTED(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 씨드 형식입니다."),
+    LINK_IS_NECESSARY(HttpStatus.BAD_REQUEST, "링크는 필수입니다."),
 
 
     // tag

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -41,6 +41,10 @@ public enum ErrorCode {
     IMAGE_STORE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 저장에 실패했습니다."),
     IMAGE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "이미지 파일 크기가 너무 큽니다."),
     S3_UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷에 파일을 업로드하는 중 에러가 발생했습니다."),
+    S3_DOWNLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷에서 파일을 다운로드하는 중 에러가 발생했습니다."),
+    S3_DELETE_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "S3 버킷에서 파일을 삭제하는 중 에러가 발생했습니다."),
+    MALFORMED_URL_EXCEPTION(HttpStatus.BAD_REQUEST, "잘못된 URL 형식입니다."),
+
 
     // others
     REQUEST_OK(HttpStatus.OK, "올바른 요청입니다."),

--- a/src/main/java/com/adoonge/seedzip/global/service/S3Service.java
+++ b/src/main/java/com/adoonge/seedzip/global/service/S3Service.java
@@ -1,5 +1,8 @@
 package com.adoonge.seedzip.global.service;
 
+import com.adoonge.seedzip.global.exception.ErrorCode;
+import com.adoonge.seedzip.global.exception.SeedzipException;
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Regions;
@@ -10,9 +13,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
+import java.net.MalformedURLException;
+import java.net.URL;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 @Service
 public class S3Service {
     private final AmazonS3 s3Client;
@@ -56,34 +62,29 @@ public class S3Service {
     }
 
     public void deleteDocFile(String fileUrl) {
-        // S3 버킷에서 파일 삭제 로직
-        s3Client.deleteObject("content-doc", extractKeyFromUrl(fileUrl));
+        try{
+            s3Client.deleteObject(docBucketName, extractKeyFromUrl(fileUrl));
+        }catch (AmazonServiceException e){
+            throw SeedzipException.from(ErrorCode.S3_DELETE_FAILURE);
+        }
     }
 
     public void deleteImgFile(String fileUrl) {
-        // S3 버킷에서 파일 삭제 로직
-        s3Client.deleteObject("content-img", extractKeyFromUrl(fileUrl));
+        try {
+            s3Client.deleteObject(imgBucketName, extractKeyFromUrl(fileUrl));
+        } catch (Exception e) {
+            throw SeedzipException.from(ErrorCode.S3_DELETE_FAILURE);
+        }
     }
 
     public static String extractKeyFromUrl(String url) {
-
-        String docBaseUrl = "https://content-doc.s3.ap-northeast-2.amazonaws.com/";
-        String imgBaseUrl = "https://content-img.s3.ap-northeast-2.amazonaws.com/";
-//        String imgBaseUrl = "https://content-doc.s3.ap-northeast-2.amazonaws.com/image/";
-
-        // URL이 docBaseUrl로 시작하는지 확인
-        if (url.startsWith(docBaseUrl)) {
-            String decodedString = URLDecoder.decode(url, StandardCharsets.UTF_8);
-            return decodedString.substring(docBaseUrl.length()); // docBaseUrl 뒤의 경로 추출
-        }
-        // URL이 imgBaseUrl로 시작하는지 확인
-        else if (url.startsWith(imgBaseUrl)) {
-            String decodedString = URLDecoder.decode(url, StandardCharsets.UTF_8);
-            return decodedString.substring(imgBaseUrl.length()); // imgBaseUrl 뒤의 경로 추출
-        }
-        // 어떤 기준에도 맞지 않으면 예외 처리
-        else {
-            throw new IllegalArgumentException("Invalid S3 URL: " + url);
+        try {
+            URL s3Url = new URL(url);
+            log.info(s3Url.getPath().substring(1));
+            return s3Url.getPath().substring(1);
+        } catch (MalformedURLException e){
+            throw SeedzipException.from(ErrorCode.MALFORMED_URL_EXCEPTION);
         }
     }
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,8 +1,8 @@
 package com.adoonge.seedzip.seed.controller;
 
-import com.adoonge.seedzip.content.dto.request.ContentsRequest;
 import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
+import com.adoonge.seedzip.seed.dto.request.SeedUpdateRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse.GetFilteredSeeds;
 import java.util.List;
 
@@ -124,7 +124,7 @@ public class SeedController {
     }
 
     @PostMapping(value = "/upload/{seedId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @Operation(summary = "씨드 업로드 후 파일 업로드 API", description = "씨드를 생성 후 파일을 db 및 aws에 저장하는 API입니다.")
+    @Operation(summary = "씨드 업로드 및 수정 후 파일 업로드 API", description = "씨드를 생성 후 파일을 db 및 aws에 저장하는 API입니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
             content = @Content(mediaType = "application/json",
@@ -221,15 +221,15 @@ public class SeedController {
                 schema = @Schema(implementation = ContentsAllResponse.getContents.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ApiResponse<ContentsAllResponse.contentResponse> modifySeed(
+    public ApiResponse<SeedResponse.SeedInfoSimple> modifySeed(
         @PathVariable("seedId") Long seedId,
         @Parameter(description = "JSON 요청 데이터", content = @Content(mediaType = "application/json"))
-        @RequestBody ContentsRequest.allContentsRequest request,
+        @RequestBody @Valid SeedUpdateRequest request,
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
-
         Member member = customUserDetails.getMember();
+        SeedResponse.SeedInfoSimple seedInfoSimple = seedService.updateSeed(request, seedId, member);
 
-        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+        return new ApiResponse<>(seedInfoSimple);
     }
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -22,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -190,6 +191,23 @@ public class SeedController {
                 categoryId,request);
 
         return new ApiResponse<>(filteredSeeds);
+    }
+
+    @DeleteMapping("/{seedId}")
+    @Operation(summary = "씨드 삭제 API", description = "씨드 삭제 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = SeedResponse.GetFilteredSeeds.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<Void> deleteSeed(@PathVariable("seedId") Long seedId,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+        seedService.deleteSeed(seedId, member);
+
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,5 +1,7 @@
 package com.adoonge.seedzip.seed.controller;
 
+import com.adoonge.seedzip.content.dto.request.ContentsRequest;
+import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse.GetFilteredSeeds;
 import java.util.List;
@@ -24,6 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -206,6 +209,25 @@ public class SeedController {
 
         Member member = customUserDetails.getMember();
         seedService.deleteSeed(seedId, member);
+
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+    }
+
+    @PatchMapping(value = "/{seedId}")
+    @Operation(summary = "씨드 수정 API", description = "씨드 내용을 수정하는 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = ContentsAllResponse.getContents.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<ContentsAllResponse.contentResponse> modifySeed(
+        @PathVariable("seedId") Long seedId,
+        @Parameter(description = "JSON 요청 데이터", content = @Content(mediaType = "application/json"))
+        @RequestBody ContentsRequest.allContentsRequest request,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
 
         return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }

--- a/src/main/java/com/adoonge/seedzip/seed/domain/File.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/File.java
@@ -59,4 +59,8 @@ public class File extends BaseEntity {
 		this.seed = seed;
 	}
 
+	public void updateLink(String link) {
+		this.link = link;
+	}
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
@@ -70,4 +70,21 @@ public class Seed extends BaseEntity {
     @OneToMany(mappedBy = "seed", fetch = FetchType.LAZY)
     private Set<CategorySeed> categorySeeds = new HashSet<>();
 
+
+    public void updateSeedName(String seedName) {
+        this.seedName = seedName;
+    }
+
+    public void updateDDay(LocalDate dDay) {
+        this.dDay = dDay;
+    }
+
+    public void updateSeedDetail(String seedDetail) {
+        this.seedDetail = seedDetail;
+    }
+
+    public void updateThumbnailIdx(Long thumbnailIdx) {
+        this.thumbnailIdx = thumbnailIdx;
+    }
+
 }

--- a/src/main/java/com/adoonge/seedzip/seed/dto/projection/SeedProjectionResult.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/projection/SeedProjectionResult.java
@@ -1,0 +1,14 @@
+package com.adoonge.seedzip.seed.dto.projection;
+
+import java.util.List;
+import java.util.Map;
+
+
+public record SeedProjectionResult(
+	Map<Long, String> thumbnailMap,
+	Map<Long, List<Long>> categoryIdMap,
+	Map<Long, List<String>> categoryNameMap,
+	Map<Long, List<Long>> tagIdMap,
+	Map<Long, List<String>> tagNameMap
+) {
+}

--- a/src/main/java/com/adoonge/seedzip/seed/dto/request/SeedUpdateRequest.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/request/SeedUpdateRequest.java
@@ -7,13 +7,13 @@ import com.adoonge.seedzip.seed.domain.SeedType;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record SeedRequest(
+public record SeedUpdateRequest(
 	@NotNull SeedType seedType,
 	String seedName,    // 없으면 null
 	@NotNull String[] boardCategories,
 	Long thumbnailImage,    // 없으면 null
 	String seedLink, // link만 해당, 나머지 null
-	@NotNull @Size(min = 2, message = "태그는 2개 이상 선택해야합니다.") String[] tags,
+	@NotNull @Size(min = 2, message = "태그는 최소 2개 이상 입력해야 합니다.") String[] tags,
 	LocalDate dDay,    // 없으면 null
 	String seedDetail    // 없으면 null
 ) {

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -25,5 +25,5 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
         "FROM CategorySeed cs WHERE cs.seed.id IN :seedIds")
     List<CategorySeedProjection> findCategoryInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 
-    void deleteCategorySeedsBySeedId(Long seedId);
+    void deleteAllBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -24,4 +24,6 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
     @Query("SELECT cs.seed.id as seedId, cs.category.categoryId as categoryId, cs.category.name as categoryName " +
         "FROM CategorySeed cs WHERE cs.seed.id IN :seedIds")
     List<CategorySeedProjection> findCategoryInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
+
+    void deleteCategorySeedsBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -22,4 +22,8 @@ public interface FileRepository extends JpaRepository<File, Long> {
     @Query("SELECT f.seed.id AS seedId, f.seed.seedType AS seedType, f.link AS link, f.isThumbnail AS isThumbnail " +
         "FROM File f WHERE f.seed.id IN :seedIds")
     List<FileSeedProjection> findFileInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
+
+    void deleteFilesBySeedId(Long seedId);
+
+    List<File> findFilesBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -23,7 +23,7 @@ public interface FileRepository extends JpaRepository<File, Long> {
         "FROM File f WHERE f.seed.id IN :seedIds")
     List<FileSeedProjection> findFileInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 
-    void deleteFilesBySeedId(Long seedId);
+    void deleteAllBySeedId(Long seedId);
 
     List<File> findFilesBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -22,7 +22,7 @@ public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
         "FROM SeedTag st WHERE st.seed.id IN :seedIds")
     List<SeedTagProjection> findTagInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 
-    void deleteSeedTagsBySeedId(Long seedId);
+    void deleteAllBySeedId(Long seedId);
 
     List<SeedTag> findSeedTagsBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -21,4 +21,8 @@ public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
     @Query("SELECT st.seed.id as seedId, st.tag.id as tagId, st.tag.tagName as tagName " +
         "FROM SeedTag st WHERE st.seed.id IN :seedIds")
     List<SeedTagProjection> findTagInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
+
+    void deleteSeedTagsBySeedId(Long seedId);
+
+    List<SeedTag> findSeedTagsBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -68,4 +68,16 @@ public class FileService {
 			}
 		);
 	}
+
+	public void deleteFiles(SeedType seedType, List<File> files){
+		if(seedType == SeedType.IMAGE){
+			files.forEach(image -> {
+				s3Service.deleteImgFile(image.getLink());
+			});
+		} else if (seedType == SeedType.PDF) {
+			files.forEach(doc -> {
+				s3Service.deleteDocFile(doc.getLink());
+			});
+		}
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/FileService.java
@@ -69,15 +69,11 @@ public class FileService {
 		);
 	}
 
-	public void deleteFiles(SeedType seedType, List<File> files){
+	public void deleteFiles(SeedType seedType, List<String> files){
 		if(seedType == SeedType.IMAGE){
-			files.forEach(image -> {
-				s3Service.deleteImgFile(image.getLink());
-			});
+			files.forEach(s3Service::deleteImgFile);
 		} else if (seedType == SeedType.PDF) {
-			files.forEach(doc -> {
-				s3Service.deleteDocFile(doc.getLink());
-			});
+			files.forEach(s3Service::deleteDocFile);
 		}
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -18,6 +18,7 @@ import com.adoonge.seedzip.seed.dto.projection.SeedProjectionResult;
 import com.adoonge.seedzip.seed.dto.projection.SeedTagProjection;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedRequest;
+import com.adoonge.seedzip.seed.dto.request.SeedUpdateRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse;
 import com.adoonge.seedzip.seed.repository.CategorySeedRepository;
 import com.adoonge.seedzip.seed.repository.FileRepository;
@@ -36,6 +37,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -170,7 +173,7 @@ public class SeedService {
 
 	@Transactional
 	public SeedResponse.SeedInfoSimple uploadSeed(SeedRequest seedRequest, Member member) {
-		if(seedRequest.seedType() == SeedType.LINK && seedRequest.contentLink() == null) {
+		if(seedRequest.seedType() == SeedType.LINK && seedRequest.seedLink() == null) {
 			throw SeedzipException.from(ErrorCode.EMPTY_LINK);
 		}
 
@@ -181,7 +184,7 @@ public class SeedService {
 		saveSeedCategories(seedRequest.boardCategories(), member, seed);
 
 		if (seedRequest.seedType() == SeedType.LINK) {
-			fileService.saveLink(seedRequest.contentLink(), seed);
+			fileService.saveLink(seedRequest.seedLink(), seed);
 		}
 
 		return SeedResponse.SeedInfoSimple
@@ -202,8 +205,7 @@ public class SeedService {
 
 	@Transactional(readOnly = true)
 	public SeedResponse.SeedDetail getSeedDetail(Long seedId, Member member) {
-		Seed seed = seedRepository.findById(seedId)
-				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
+		Seed seed = getSeedOrThrow(seedId);
 		List<File> files = fileRepository.findAllBySeed(seed)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
 
@@ -394,11 +396,11 @@ public class SeedService {
 
 		//콘텐츠 소유자 검증
 		if (!seed.getMember().getId().equals(member.getId())) {
-			throw SeedzipException.from(ErrorCode.CATEGORY_ACCESS_DENIED);
+			throw SeedzipException.from(ErrorCode.MEMBER_NOT_OWNER);
 		}
 
 		//카테고리 매핑 삭제
-		categorySeedRepository.deleteCategorySeedsBySeedId(id);
+		categorySeedRepository.deleteAllBySeedId(id);
 
 		//S3에서 파일 삭제
 		List<String> fileLinks = fileRepository.findFilesBySeedId(id).stream()
@@ -407,12 +409,75 @@ public class SeedService {
 		fileService.deleteFiles(seed.getSeedType(), fileLinks);
 
 		//파일 삭제
-		fileRepository.deleteFilesBySeedId(id);
+		fileRepository.deleteAllBySeedId(id);
 
 		//태그 매핑 삭제
-		seedTagRepository.deleteSeedTagsBySeedId(id);
+		seedTagRepository.deleteAllBySeedId(id);
 
 		seedRepository.delete(seed);
+	}
+
+	// 콘텐츠 수정
+	@Transactional
+	public SeedResponse.SeedInfoSimple updateSeed(SeedUpdateRequest request,
+		Long seedId, Member member) {
+		if(request.seedType() == SeedType.LINK && request.seedLink() == null) {
+			throw SeedzipException.from(ErrorCode.EMPTY_LINK);
+		}
+
+		Seed seed = getSeedOrThrow(seedId);
+		if(!request.seedType().equals(seed.getSeedType())) {
+			throw SeedzipException.from(ErrorCode.SEED_TYPE_NOT_SUPPORTED);
+		}
+
+		//콘텐츠 소유자 검증
+		if (!seed.getMember().getId().equals(member.getId())) {
+			throw SeedzipException.from(ErrorCode.MEMBER_NOT_OWNER);
+		}
+
+		// 기본 필드 수정
+		if (!Objects.equals(seed.getSeedName(), request.seedName())) {
+			seed.updateSeedName(request.seedName());
+		}
+		if (!Objects.equals(seed.getDDay(), request.dDay())) {
+			seed.updateDDay(request.dDay());
+		}
+		if (!Objects.equals(seed.getSeedDetail(), request.seedDetail())) {
+			seed.updateSeedDetail(request.seedDetail());
+		}
+		if (!Objects.equals(seed.getThumbnailIdx(), request.thumbnailImage())) {
+			seed.updateThumbnailIdx(request.thumbnailImage());
+		}
+
+		// 태그
+		seedTagRepository.deleteAllBySeedId(seedId);
+		saveSeedTags(request.tags(), member, seed);
+
+		// 카테고리
+		categorySeedRepository.deleteAllBySeedId(seedId);
+		saveSeedCategories(request.boardCategories(), member, seed);
+
+		if (seed.getSeedType().equals(SeedType.LINK)) {
+			File file = fileRepository.findBySeed(seed).orElseThrow(
+				() -> SeedzipException.from(ErrorCode.FILE_NOT_FOUND)
+			);
+			if (!Objects.equals(file.getLink(), request.seedLink())) {
+				file.updateLink(request.seedLink());
+			}
+		} else {    // 이미지, PDF
+			List<String> fileLinks = fileRepository.findFilesBySeedId(seedId).stream()
+				.map(File::getLink)
+				.toList();
+			fileService.deleteFiles(seed.getSeedType(), fileLinks);
+
+			fileRepository.deleteAllBySeedId(seedId);
+		}
+
+		Seed updatedSeed = seedRepository.save(seed);
+		return SeedResponse.SeedInfoSimple.builder()
+			.seedId(updatedSeed.getId())
+			.seedName(updatedSeed.getSeedName())
+			.build();
 	}
 
 	private SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {
@@ -640,6 +705,11 @@ public class SeedService {
 		return tagProjections.stream()
 				.collect(Collectors.groupingBy(SeedTagProjection::getSeedId,
 						Collectors.mapping(SeedTagProjection::getTagName, Collectors.toList())));
+	}
+
+	private Seed getSeedOrThrow(Long seedId) {
+		return seedRepository.findById(seedId)
+			.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
 	}
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -14,6 +14,7 @@ import com.adoonge.seedzip.seed.domain.mapping.SeedTag;
 import com.adoonge.seedzip.seed.dto.SeedDTO;
 import com.adoonge.seedzip.seed.dto.projection.CategorySeedProjection;
 import com.adoonge.seedzip.seed.dto.projection.FileSeedProjection;
+import com.adoonge.seedzip.seed.dto.projection.SeedProjectionResult;
 import com.adoonge.seedzip.seed.dto.projection.SeedTagProjection;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedRequest;
@@ -35,7 +36,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -99,21 +99,9 @@ public class SeedService {
 				.map(Seed::getId)
 				.toList();
 
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
-		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
-		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
-
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(),seedProjectionResult);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -160,21 +148,9 @@ public class SeedService {
 				.map(Seed::getId)
 				.toList();
 
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
-		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
-		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
-
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(),seedProjectionResult);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -301,22 +277,9 @@ public class SeedService {
 				.map(Seed::getId)
 				.toList();
 
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
-		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
-		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(
-				seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent(),seedProjectionResult);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -361,22 +324,9 @@ public class SeedService {
 				.map(Seed::getId)
 				.toList();
 
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
-		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
-		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(
-				seedList.getContent(), thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent(), seedProjectionResult);
 
 		//페이징 정보 추가
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -417,22 +367,9 @@ public class SeedService {
 				.map(Seed::getId)
 				.toList();
 
-		// 파일 프로젝션으로 썸네일 처리
-		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
-		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
-		// 카테고리 projection
-		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
-		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
-
-		// 태그 projection
-		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
-		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
-		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(
-				seedList, thumbnailMap, categoryIdMap, categoryNameMap, tagIdMap, tagNameMap);
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(seedList, seedProjectionResult);
 
 
 		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
@@ -448,6 +385,30 @@ public class SeedService {
 				.seedInfoList(seedInfoWithSeedDetails)
 				.pageInfo(pageInfo)
 				.build();
+	}
+
+	public SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {
+		// 파일 프로젝션
+		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
+		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);
+
+		// 카테고리 프로젝션
+		List<CategorySeedProjection> categoryProjections = categorySeedRepository.findCategoryInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> categoryIdMap = getCategoryIdMap(categoryProjections);
+		Map<Long, List<String>> categoryNameMap = getCategoryNameMap(categoryProjections);
+
+		// 태그 프로젝션
+		List<SeedTagProjection> tagProjections = seedTagRepository.findTagInfoBySeedIds(seedIds);
+		Map<Long, List<Long>> tagIdMap = getTagIdMap(tagProjections);
+		Map<Long, List<String>> tagNameMap = getTagNameMap(tagProjections);
+
+		return new SeedProjectionResult(
+			thumbnailMap,
+			categoryIdMap,
+			categoryNameMap,
+			tagIdMap,
+			tagNameMap
+		);
 	}
 
 	private Seed saveSeed(SeedRequest seedRequest, Member member) {
@@ -519,11 +480,13 @@ public class SeedService {
 	//List<Seed> -> List<SeedResponse.SeedInfo>로 변환
 	private List<SeedResponse.SeedInfo> generateResponseFromSeedList(
 			List<Seed> seedList,
-			Map<Long, String> thumbnailMap,
-			Map<Long, List<Long>> categoryIdMap,
-			Map<Long, List<String>> categoryNameMap,
-			Map<Long, List<Long>> tagIdMap,
-			Map<Long, List<String>> tagNameMap) {
+			SeedProjectionResult seedProjectionResult) {
+		Map<Long, String> thumbnailMap = seedProjectionResult.thumbnailMap();
+		Map<Long, List<Long>> categoryIdMap = seedProjectionResult.categoryIdMap();
+		Map<Long, List<String>> categoryNameMap = seedProjectionResult.categoryNameMap();
+		Map<Long, List<Long>> tagIdMap = seedProjectionResult.tagIdMap();
+		Map<Long, List<String>> tagNameMap = seedProjectionResult.tagNameMap();
+
 		return seedList.stream()
 				.map(seed -> {
 					Long seedId = seed.getId();
@@ -554,12 +517,14 @@ public class SeedService {
 	//List<Seed> -> List<SeedResponse.SeedInfoWithSeedDetail>로 변환 Refact
 	private List<SeedResponse.SeedInfoWithSeedDetail> generateResponseWithDetailFromSeedList(
 		List<Seed> seedList,
-		Map<Long, String> thumbnailMap,
-		Map<Long, List<Long>> categoryIdMap,
-		Map<Long, List<String>> categoryNameMap,
-		Map<Long, List<Long>> tagIdMap,
-		Map<Long, List<String>> tagNameMap
+		SeedProjectionResult seedProjectionResult
 	) {
+		Map<Long, String> thumbnailMap = seedProjectionResult.thumbnailMap();
+		Map<Long, List<Long>> categoryIdMap = seedProjectionResult.categoryIdMap();
+		Map<Long, List<String>> categoryNameMap = seedProjectionResult.categoryNameMap();
+		Map<Long, List<Long>> tagIdMap = seedProjectionResult.tagIdMap();
+		Map<Long, List<String>> tagNameMap = seedProjectionResult.tagNameMap();
+
 		return seedList.stream()
 			.map(seed -> {
 				Long seedId = seed.getId();

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -400,12 +400,14 @@ public class SeedService {
 		//카테고리 매핑 삭제
 		categorySeedRepository.deleteCategorySeedsBySeedId(id);
 
+		//S3에서 파일 삭제
+		List<String> fileLinks = fileRepository.findFilesBySeedId(id).stream()
+			.map(File::getLink)
+			.toList();
+		fileService.deleteFiles(seed.getSeedType(), fileLinks);
+
 		//파일 삭제
 		fileRepository.deleteFilesBySeedId(id);
-
-		//S3에서 파일 삭제
-		List<File> existingFiles = fileRepository.findFilesBySeedId(id);
-		fileService.deleteFiles(seed.getSeedType(), existingFiles);
 
 		//태그 매핑 삭제
 		seedTagRepository.deleteSeedTagsBySeedId(id);

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -387,7 +387,31 @@ public class SeedService {
 				.build();
 	}
 
+	@Transactional
+	public void deleteSeed(Long id, Member member) {
+		Seed seed = seedRepository.findById(id)
+			.orElseThrow(() -> SeedzipException.from(ErrorCode.CONTENT_ACCESS_DENIED));
 
+		//콘텐츠 소유자 검증
+		if (!seed.getMember().getId().equals(member.getId())) {
+			throw SeedzipException.from(ErrorCode.CATEGORY_ACCESS_DENIED);
+		}
+
+		//카테고리 매핑 삭제
+		categorySeedRepository.deleteCategorySeedsBySeedId(id);
+
+		//파일 삭제
+		fileRepository.deleteFilesBySeedId(id);
+
+		//S3에서 파일 삭제
+		List<File> existingFiles = fileRepository.findFilesBySeedId(id);
+		fileService.deleteFiles(seed.getSeedType(), existingFiles);
+
+		//태그 매핑 삭제
+		seedTagRepository.deleteSeedTagsBySeedId(id);
+
+		seedRepository.delete(seed);
+	}
 
 	private SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {
 		// 파일 프로젝션

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -387,7 +387,9 @@ public class SeedService {
 				.build();
 	}
 
-	public SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {
+
+
+	private SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {
 		// 파일 프로젝션
 		List<FileSeedProjection> fileProjections = fileRepository.findFileInfoBySeedIds(seedIds);
 		Map<Long, String> thumbnailMap = getThumbnailMap(fileProjections);


### PR DESCRIPTION
## 🪺 Summary
씨드 수정 및 삭제
- 삭제 api : 기존에는 api 두번 호출해야 했었는데 한번에 s3삭제 로직까지 가능하도록 변경
- 수정 api : 기본필드들은 update메소드를 정의해서 변경해주었고 매핑엔티티들과 파일은 삭제 후 재생성 방식으로 구현함.
- 수정 api에서 이미지, 피뎊의 경우 수정 완료 후 파일 업로드 api를 호출하도록하여 재사용성을 높임
- getSeedProjectionResult를 만들어 중복을 최소화하고 dto에 담아 리턴하도록함

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #131 


## 🙏 To Reviewers
