### PR TITLE
Feat : 앱 메인페이지 구현 및 조회수 로직 추가 (#141)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,12 @@ dependencies {
 
 	//Jsoup
 	implementation 'org.jsoup:jsoup:1.15.4'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// Spring Boot Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 bootJar {

--- a/src/main/java/com/adoonge/seedzip/SeedzipApplication.java
+++ b/src/main/java/com/adoonge/seedzip/SeedzipApplication.java
@@ -2,8 +2,10 @@ package com.adoonge.seedzip;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableCaching
 @SpringBootApplication
 //@EnableJpaAuditing
 public class SeedzipApplication {

--- a/src/main/java/com/adoonge/seedzip/SeedzipApplication.java
+++ b/src/main/java/com/adoonge/seedzip/SeedzipApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableCaching
 @SpringBootApplication
+@EnableScheduling
 //@EnableJpaAuditing
 public class SeedzipApplication {
 

--- a/src/main/java/com/adoonge/seedzip/app/controller/AppController.java
+++ b/src/main/java/com/adoonge/seedzip/app/controller/AppController.java
@@ -37,7 +37,6 @@ public class AppController {
 	public ApiResponse<AppMainResponse> getAllSeeds(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
 		Member member = customUserDetails.getMember();
-		appService.getAppMain(member);
 		return new ApiResponse<>(appService.getAppMain(member));
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/app/controller/AppController.java
+++ b/src/main/java/com/adoonge/seedzip/app/controller/AppController.java
@@ -1,0 +1,43 @@
+package com.adoonge.seedzip.app.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.adoonge.seedzip.app.dto.response.AppMainResponse;
+import com.adoonge.seedzip.app.service.AppService;
+import com.adoonge.seedzip.auth.util.CustomUserDetails;
+import com.adoonge.seedzip.global.dto.response.ApiResponse;
+import com.adoonge.seedzip.member.domain.Member;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/app")
+@RequiredArgsConstructor
+@Tag(name = "AppController", description = "앱 전용 API")
+public class AppController {
+
+	private final AppService appService;
+
+	@GetMapping("/main")
+	@Operation(summary = "앱 메인페이지 유저 활동 정보 API", description = "앱 메인페이지에서 유저의 활동 정보를 가져오는 API")
+	@ApiResponses(value = {
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+			content = @Content(mediaType = "application/json",
+				schema = @Schema(implementation = AppMainResponse.class))),
+		@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+	})
+	public ApiResponse<AppMainResponse> getAllSeeds(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+		Member member = customUserDetails.getMember();
+		appService.getAppMain(member);
+		return new ApiResponse<>(appService.getAppMain(member));
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/app/dto/response/AppMainResponse.java
+++ b/src/main/java/com/adoonge/seedzip/app/dto/response/AppMainResponse.java
@@ -1,0 +1,16 @@
+package com.adoonge.seedzip.app.dto.response;
+
+import java.time.LocalDate;
+
+import lombok.Builder;
+
+@Builder
+public record AppMainResponse(
+	LocalDate localDate,
+	String userName,
+	Long todaySeedCount,
+	Long totalSeedCount,
+	Long mostReadSeedCount,
+	Long neverReadSeedCount
+) {
+}

--- a/src/main/java/com/adoonge/seedzip/app/dto/response/AppMainResponse.java
+++ b/src/main/java/com/adoonge/seedzip/app/dto/response/AppMainResponse.java
@@ -2,6 +2,9 @@ package com.adoonge.seedzip.app.dto.response;
 
 import java.time.LocalDate;
 
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.seed.dto.SeedStatisticsDTO;
+
 import lombok.Builder;
 
 @Builder
@@ -13,4 +16,18 @@ public record AppMainResponse(
 	Long mostReadSeedCount,
 	Long neverReadSeedCount
 ) {
+	public static AppMainResponse from(
+		Member member,
+		Long todaySeedCount,
+		SeedStatisticsDTO seedStatisticsDTO
+	){
+		return AppMainResponse.builder()
+			.localDate(LocalDate.now())
+			.userName(member.getNickname())
+			.todaySeedCount(todaySeedCount)
+			.totalSeedCount(seedStatisticsDTO.totalSeedCount())
+			.mostReadSeedCount(seedStatisticsDTO.mostReadSeedCount())
+			.neverReadSeedCount(seedStatisticsDTO.neverReadSeedCount())
+			.build();
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/app/service/AppService.java
+++ b/src/main/java/com/adoonge/seedzip/app/service/AppService.java
@@ -1,0 +1,26 @@
+package com.adoonge.seedzip.app.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.adoonge.seedzip.app.dto.response.AppMainResponse;
+import com.adoonge.seedzip.member.domain.Member;
+import com.adoonge.seedzip.member.service.MemberService;
+import com.adoonge.seedzip.seed.service.SeedService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppService {
+
+	private final MemberService memberService;
+	private final SeedService seedService;
+
+	public AppMainResponse getAppMain(Member member) {
+
+		return null;
+
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/app/service/AppService.java
+++ b/src/main/java/com/adoonge/seedzip/app/service/AppService.java
@@ -1,12 +1,14 @@
 package com.adoonge.seedzip.app.service;
 
+import java.time.LocalDate;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.adoonge.seedzip.app.dto.response.AppMainResponse;
 import com.adoonge.seedzip.member.domain.Member;
-import com.adoonge.seedzip.member.service.MemberService;
-import com.adoonge.seedzip.seed.service.SeedService;
+import com.adoonge.seedzip.seed.repository.SeedRepository;
+import com.adoonge.seedzip.seed.repository.SeedRepositoryCustom;
 
 import lombok.RequiredArgsConstructor;
 
@@ -14,13 +16,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AppService {
-
-	private final MemberService memberService;
-	private final SeedService seedService;
+	private final SeedRepositoryCustom seedRepositoryCustom;
+	private final SeedRepository seedRepository;
 
 	public AppMainResponse getAppMain(Member member) {
+		LocalDate today = LocalDate.now();
 
-		return null;
-
+		return AppMainResponse.from(
+			member,
+			seedRepository.countByCreatedAtBetween(today.atStartOfDay(), today.plusDays(1).atStartOfDay()),
+			seedRepositoryCustom.getSeedStatistics(member)
+		);
 	}
 }

--- a/src/main/java/com/adoonge/seedzip/global/config/RedisCacheConfig.java
+++ b/src/main/java/com/adoonge/seedzip/global/config/RedisCacheConfig.java
@@ -1,0 +1,36 @@
+package com.adoonge.seedzip.global.config;
+
+import java.time.Duration;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@EnableCaching
+@Configuration
+public class RedisCacheConfig {
+
+	@Bean
+	public CacheManager contentCacheManager(RedisConnectionFactory cf) {
+		RedisCacheConfiguration redisCacheConfiguration =
+			RedisCacheConfiguration.defaultCacheConfig()
+				.serializeKeysWith(
+					RedisSerializationContext.SerializationPair.fromSerializer(
+						new StringRedisSerializer()))
+				.serializeValuesWith(
+					RedisSerializationContext.SerializationPair.fromSerializer(
+						new GenericJackson2JsonRedisSerializer()))
+				.entryTtl(Duration.ofDays(7)); // 캐시 수명 7일
+
+		return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf)
+			.cacheDefaults(redisCacheConfiguration)
+			.build();
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/global/config/RedisConfig.java
+++ b/src/main/java/com/adoonge/seedzip/global/config/RedisConfig.java
@@ -1,0 +1,42 @@
+package com.adoonge.seedzip.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+	@Value("${spring.data.redis.host}")
+	private String redisHost;
+
+	@Value("${spring.data.redis.port}")
+	private int redisPort;
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		RedisStandaloneConfiguration redisStandaloneConfiguration =
+			new RedisStandaloneConfiguration(redisHost, redisPort);
+		return new LettuceConnectionFactory(redisStandaloneConfiguration);
+	}
+
+	@Bean
+	public RedisTemplate<String, Object> redisTemplate() {
+		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+		StringRedisSerializer stringSerializer = new StringRedisSerializer();
+		redisTemplate.setKeySerializer(stringSerializer);
+		redisTemplate.setValueSerializer(stringSerializer);
+		redisTemplate.setHashKeySerializer(stringSerializer);
+		redisTemplate.setHashValueSerializer(stringSerializer);
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		return redisTemplate;
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/global/config/RedisConfig.java
+++ b/src/main/java/com/adoonge/seedzip/global/config/RedisConfig.java
@@ -20,10 +20,14 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int redisPort;
 
+	@Value("${spring.data.redis.password:}")
+	private String redisPassword;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
 		RedisStandaloneConfiguration redisStandaloneConfiguration =
 			new RedisStandaloneConfiguration(redisHost, redisPort);
+		redisStandaloneConfiguration.setPassword(redisPassword);
 		return new LettuceConnectionFactory(redisStandaloneConfiguration);
 	}
 

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -101,7 +101,7 @@ public class SeedController {
 
         Member member = customUserDetails.getMember();
 
-        return new ApiResponse<>(seedService.getSeedDetail(seedId, member));
+        return new ApiResponse<>(seedService.getSeedDetail(seedId));
     }
 
     @PostMapping

--- a/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
+++ b/src/main/java/com/adoonge/seedzip/seed/domain/Seed.java
@@ -56,6 +56,9 @@ public class Seed extends BaseEntity {
 
     private Long thumbnailIdx;  // seedType = LINK, PDF인 경우 null
 
+    @Column(name = "view_count", nullable = false)
+    private long viewCount = 0L; // 조회수
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     @OnDelete(action = OnDeleteAction.CASCADE) // Member 삭제 시 Content도 삭제

--- a/src/main/java/com/adoonge/seedzip/seed/dto/SeedStatisticsDTO.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/SeedStatisticsDTO.java
@@ -1,0 +1,8 @@
+package com.adoonge.seedzip.seed.dto;
+
+public record SeedStatisticsDTO(
+	Long totalSeedCount,
+	Long mostReadSeedCount,
+	Long neverReadSeedCount
+) {
+}

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-import io.lettuce.core.dynamic.annotation.Param;
+import org.springframework.data.repository.query.Param;
 import jakarta.transaction.Transactional;
 
 public interface SeedRepository extends JpaRepository<Seed, Long> {

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -12,6 +12,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.transaction.Transactional;
 
 public interface SeedRepository extends JpaRepository<Seed, Long> {
@@ -30,4 +31,7 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 	@Query("DELETE FROM Seed s WHERE NOT EXISTS (SELECT 1 FROM CategorySeed cs WHERE cs.seed.id = s.id)")
 	default void deleteUnreferencedContents() {}
 
+	@Modifying
+	@Query("UPDATE Seed s SET s.viewCount = s.viewCount + :count WHERE s.id = :seedId")
+	void incrementViews(@Param("seedId") Long seedId, @Param("count") Long count);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -4,6 +4,7 @@ import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -34,4 +35,6 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 	@Modifying
 	@Query("UPDATE Seed s SET s.viewCount = s.viewCount + :count WHERE s.id = :seedId")
 	void incrementViews(@Param("seedId") Long seedId, @Param("count") Long count);
+
+	long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
@@ -7,6 +7,7 @@ import com.adoonge.seedzip.content.domain.Contents;
 import com.adoonge.seedzip.member.domain.Member;
 import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
+import com.adoonge.seedzip.seed.dto.SeedStatisticsDTO;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,4 +21,5 @@ public interface SeedRepositoryCustom {
         List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberId
     );
 
+    SeedStatisticsDTO getSeedStatistics(Member member);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -63,10 +63,14 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
 		if(result == null) {
 			return new SeedStatisticsDTO(0L, 0L, 0L);
 		}
+		Number total = result.get(0, Number.class);
+		Number mostRead = result.get(1, Number.class);
+		Number neverRead = result.get(2, Number.class);
+
 		return new SeedStatisticsDTO(
-			result.get(0, Long.class) != null ? result.get(0, Long.class) : 0L,
-			result.get(1, Long.class) != null ? result.get(1, Long.class) : 0L,
-			result.get(2, Long.class) != null ? result.get(2, Long.class) : 0L
+			total != null ? total.longValue() : 0L,
+			mostRead != null ? mostRead.longValue() : 0L,
+			neverRead != null ? neverRead.longValue() : 0L
 		);
 	}
 

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -9,11 +9,14 @@ import com.adoonge.seedzip.seed.domain.Seed;
 import com.adoonge.seedzip.seed.domain.SeedType;
 import com.adoonge.seedzip.seed.domain.mapping.QCategorySeed;
 import com.adoonge.seedzip.seed.domain.mapping.QSeedTag;
+import com.adoonge.seedzip.seed.dto.SeedStatisticsDTO;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.tag.domain.QTag;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.core.types.dsl.DateTimePath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -21,8 +24,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
+
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -30,261 +34,291 @@ import org.springframework.data.domain.Sort;
 
 @RequiredArgsConstructor
 public class SeedRepositoryImpl implements SeedRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
 
-    private final JPAQueryFactory queryFactory;
-    private static final Set<String> ALLOWED_SORT_FIELDS = Set.of("name", "latest");
+	QSeed seed = QSeed.seed;
+	QSeedTag seedTag = QSeedTag.seedTag;
+	QTag tag = QTag.tag;
+	QCategorySeed categorySeed = QCategorySeed.categorySeed;
+	QFilterTag filterTag = QFilterTag.filterTag;
 
-    QSeed seed = QSeed.seed;
-    QSeedTag seedTag = QSeedTag.seedTag;
-    QTag tag = QTag.tag;
-    QCategorySeed categorySeed = QCategorySeed.categorySeed;
-    QFilterTag filterTag = QFilterTag.filterTag;
+	@Override
+	public SeedStatisticsDTO getSeedStatistics(Member member) {
+		Tuple result = queryFactory
+			.select(
+				seed.count(),
+				new CaseBuilder()
+					.when(seed.viewCount.goe(3L)).then(1)
+					.otherwise(0)
+					.sum(),
+				new CaseBuilder()
+					.when(seed.viewCount.eq(0L)).then(1)
+					.otherwise(0)
+					.sum()
+			)
+			.from(seed)
+			.where(seed.member.eq(member))
+			.fetchOne();
 
-    @Override
-    public Page<Seed> findSeedsByFiltering(Member member, Pageable pageable, SeedType seedType, SeedFilteringRequest request) {
-        List<String> tagNames = request.tags();
-        String keyword = request.keyword();
+		if(result == null) {
+			return new SeedStatisticsDTO(0L, 0L, 0L);
+		}
+		return new SeedStatisticsDTO(
+			result.get(0, Long.class) != null ? result.get(0, Long.class) : 0L,
+			result.get(1, Long.class) != null ? result.get(1, Long.class) : 0L,
+			result.get(2, Long.class) != null ? result.get(2, Long.class) : 0L
+		);
+	}
 
-        BooleanExpression condition = seed.member.eq(member);
+	@Override
+	public Page<Seed> findSeedsByFiltering(Member member, Pageable pageable, SeedType seedType,
+		SeedFilteringRequest request) {
+		List<String> tagNames = request.tags();
+		String keyword = request.keyword();
 
-        condition = safeAnd(condition, filteringByTagNames(tagNames));
-        condition = safeAnd(condition, filteringByKeyword(keyword));
-        condition = safeAnd(condition, filteringBySeedType(seedType));
+		BooleanExpression condition = seed.member.eq(member);
 
-        List<Seed> content = queryFactory
-                .selectFrom(seed)
-                .where(condition)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(getOrderSpecifiers(pageable.getSort()))
-                .fetch();
+		condition = safeAnd(condition, filteringByTagNames(tagNames));
+		condition = safeAnd(condition, filteringByKeyword(keyword));
+		condition = safeAnd(condition, filteringBySeedType(seedType));
 
-        Long total = queryFactory
-                .select(seed.count())
-                .from(seed)
-                .where(condition)
-                .fetchOne();
+		List<Seed> content = queryFactory
+			.selectFrom(seed)
+			.where(condition)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(getOrderSpecifiers(pageable.getSort()))
+			.fetch();
 
-        return new PageImpl<>(content, pageable, total != null ? total : 0);
-    }
+		Long total = queryFactory
+			.select(seed.count())
+			.from(seed)
+			.where(condition)
+			.fetchOne();
 
-    @Override
-    public Page<Seed> findCategorySeedsByFiltering(Member member, Pageable pageable, SeedType seedType, Long categoryId,
-                                                   SeedFilteringRequest request) {
-        List<String> tagNames = request.tags();
-        String keyword = request.keyword();
+		return new PageImpl<>(content, pageable, total != null ? total : 0);
+	}
 
-        BooleanExpression condition = seed.member.eq(member);
+	@Override
+	public Page<Seed> findCategorySeedsByFiltering(Member member, Pageable pageable, SeedType seedType, Long categoryId,
+		SeedFilteringRequest request) {
+		List<String> tagNames = request.tags();
+		String keyword = request.keyword();
 
-        condition = safeAnd(condition, filteringByCategory(categoryId));
-        condition = safeAnd(condition, filteringByTagNames(tagNames));
-        condition = safeAnd(condition, filteringByKeyword(keyword));
-        condition = safeAnd(condition, filteringBySeedType(seedType));
+		BooleanExpression condition = seed.member.eq(member);
 
-        List<Seed> content = queryFactory
-                .selectFrom(seed)
-                .where(condition)
-                .offset(pageable.getOffset())
-                .limit(pageable.getPageSize())
-                .orderBy(getOrderSpecifiers(pageable.getSort()))
-                .fetch();
+		condition = safeAnd(condition, filteringByCategory(categoryId));
+		condition = safeAnd(condition, filteringByTagNames(tagNames));
+		condition = safeAnd(condition, filteringByKeyword(keyword));
+		condition = safeAnd(condition, filteringBySeedType(seedType));
 
-        Long total = queryFactory
-                .select(seed.count())
-                .from(seed)
-                .where(condition)
-                .fetchOne();
+		List<Seed> content = queryFactory
+			.selectFrom(seed)
+			.where(condition)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.orderBy(getOrderSpecifiers(pageable.getSort()))
+			.fetch();
 
-        return new PageImpl<>(content, pageable, total != null ? total : 0);
-    }
+		Long total = queryFactory
+			.select(seed.count())
+			.from(seed)
+			.where(condition)
+			.fetchOne();
 
-    @Override
-    public Page<Seed> findSeedsByCustomFilter(Pageable pageable, LocalDate startDate, LocalDate endDate,
-        List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberID) {
+		return new PageImpl<>(content, pageable, total != null ? total : 0);
+	}
 
-        BooleanExpression condition = seed.member.id.eq(memberID);
-        condition = safeAnd(condition, filterByDate(startDate, endDate));
-        condition = safeAnd(condition, filterByDDay(dDayStart, dDayEnd));
-        condition = safeAnd(condition, filterByStorageFormat(seedType));
-        condition = safeAnd(condition, filterByTags(filterId));
+	@Override
+	public Page<Seed> findSeedsByCustomFilter(Pageable pageable, LocalDate startDate, LocalDate endDate,
+		List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberID) {
 
-        // 1. 페이징 대상 Seed ID 조회
-        // List<Long> seedIds = queryFactory
-        //     .select(seed.id)
-        //     .from(seed)
-        //     .where(condition)
-        //     .offset(pageable.getOffset())
-        //     .limit(pageable.getPageSize())
-        //     .fetch();
-        //
-        // // 2. 실제 Seed + 연관 데이터 조회 fetch join
-        // List<Seed> seeds = queryFactory
-        //     .selectDistinct(seed)
-        //     .from(seed)
-        //     .leftJoin(seed.files, file).fetchJoin()
-        //     .leftJoin(seed.seedTags, seedTag).fetchJoin()
-        //     .leftJoin(seedTag.tag, tag).fetchJoin()
-        //     .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
-        //     .leftJoin(categorySeed.category, category).fetchJoin()
-        //     .where(seed.id.in(seedIds))
-        //     .fetch();
+		BooleanExpression condition = seed.member.id.eq(memberID);
+		condition = safeAnd(condition, filterByDate(startDate, endDate));
+		condition = safeAnd(condition, filterByDDay(dDayStart, dDayEnd));
+		condition = safeAnd(condition, filterByStorageFormat(seedType));
+		condition = safeAnd(condition, filterByTags(filterId));
 
-        // 기존: fetch join으로 모든 걸 한 번에 가져옴 → 제거
-        List<Seed> seeds = queryFactory
-            .selectFrom(seed)
-            .where(condition)
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .fetch();
+		// 1. 페이징 대상 Seed ID 조회
+		// List<Long> seedIds = queryFactory
+		//     .select(seed.id)
+		//     .from(seed)
+		//     .where(condition)
+		//     .offset(pageable.getOffset())
+		//     .limit(pageable.getPageSize())
+		//     .fetch();
+		//
+		// // 2. 실제 Seed + 연관 데이터 조회 fetch join
+		// List<Seed> seeds = queryFactory
+		//     .selectDistinct(seed)
+		//     .from(seed)
+		//     .leftJoin(seed.files, file).fetchJoin()
+		//     .leftJoin(seed.seedTags, seedTag).fetchJoin()
+		//     .leftJoin(seedTag.tag, tag).fetchJoin()
+		//     .leftJoin(seed.categorySeeds, categorySeed).fetchJoin()
+		//     .leftJoin(categorySeed.category, category).fetchJoin()
+		//     .where(seed.id.in(seedIds))
+		//     .fetch();
 
-        Long total = queryFactory
-            .select(seed.count())
-            .from(seed)
-            .where(condition)
-            .fetchOne();
+		// 기존: fetch join으로 모든 걸 한 번에 가져옴 → 제거
+		List<Seed> seeds = queryFactory
+			.selectFrom(seed)
+			.where(condition)
+			.offset(pageable.getOffset())
+			.limit(pageable.getPageSize())
+			.fetch();
 
-        return new PageImpl<>(seeds, pageable, total != null ? total : 0);
-    }
+		Long total = queryFactory
+			.select(seed.count())
+			.from(seed)
+			.where(condition)
+			.fetchOne();
 
-    //Category 필터 조건
-    private BooleanExpression filteringByCategory(Long categoryId) {
-        if(categoryId == null) {
-            return null;
-        }
-        // Category에 해당하는 Seed ID 조회
-        List<Long> seedIds = queryFactory
-                .select(categorySeed.seed.id)
-                .from(categorySeed)
-                .where(categorySeed.category.categoryId.eq(categoryId))
-                .fetch();
+		return new PageImpl<>(seeds, pageable, total != null ? total : 0);
+	}
 
-        return seed.id.in(seedIds);
-    }
+	//Category 필터 조건
+	private BooleanExpression filteringByCategory(Long categoryId) {
+		if (categoryId == null) {
+			return null;
+		}
+		// Category에 해당하는 Seed ID 조회
+		List<Long> seedIds = queryFactory
+			.select(categorySeed.seed.id)
+			.from(categorySeed)
+			.where(categorySeed.category.categoryId.eq(categoryId))
+			.fetch();
 
-    //Tag 필터 조건
-    private BooleanExpression filteringByTagNames(List<String> tagNames) {
-        if(tagNames == null || tagNames.isEmpty()) {
-            return null;
-        }
-        // 태그 조건을 만족하는 Seed ID 조회
-        List<Long> seedIds = queryFactory
-                .select(seedTag.seed.id)
-                .from(seedTag)
-                .join(seedTag.tag, tag)
-                .where(tag.tagName.in(tagNames))
-                .groupBy(seedTag.seed.id)
-                .having(tag.tagName.countDistinct().eq((long) tagNames.size()))
-                .fetch();
+		return seed.id.in(seedIds);
+	}
 
-        return seed.id.in(seedIds);
-    }
+	//Tag 필터 조건
+	private BooleanExpression filteringByTagNames(List<String> tagNames) {
+		if (tagNames == null || tagNames.isEmpty()) {
+			return null;
+		}
+		// 태그 조건을 만족하는 Seed ID 조회
+		List<Long> seedIds = queryFactory
+			.select(seedTag.seed.id)
+			.from(seedTag)
+			.join(seedTag.tag, tag)
+			.where(tag.tagName.in(tagNames))
+			.groupBy(seedTag.seed.id)
+			.having(tag.tagName.countDistinct().eq((long)tagNames.size()))
+			.fetch();
 
-    //SeedType 필터조건
-    private BooleanExpression filteringBySeedType(SeedType seedType) {
-        return seedType != null ? seed.seedType.eq(seedType) : null;
-    }
+		return seed.id.in(seedIds);
+	}
 
-    //Keyword 필터 조건
-    private BooleanExpression filteringByKeyword(String keyword) {
-        return keyword != null && !keyword.isEmpty() ? seed.seedName.containsIgnoreCase(keyword).or(seed.seedDetail.containsIgnoreCase(keyword)) : null;
-    }
+	//SeedType 필터조건
+	private BooleanExpression filteringBySeedType(SeedType seedType) {
+		return seedType != null ? seed.seedType.eq(seedType) : null;
+	}
 
-    // 날짜 필터 조건
-    private BooleanExpression filterByDate(LocalDate startDate, LocalDate endDate) {
-        DateTimePath<LocalDateTime> createdAt = seed.createdAt;
+	//Keyword 필터 조건
+	private BooleanExpression filteringByKeyword(String keyword) {
+		return keyword != null && !keyword.isEmpty() ?
+			seed.seedName.containsIgnoreCase(keyword).or(seed.seedDetail.containsIgnoreCase(keyword)) : null;
+	}
 
-        if (startDate != null && endDate != null) {
-            if(startDate.equals(endDate)) {
-                return createdAt.between(startDate.atStartOfDay(), startDate.atStartOfDay().plusDays(1));
-            }
-            return createdAt.between(startDate.atStartOfDay(), endDate.atStartOfDay());
-        } else if (startDate != null) {
-            return createdAt.goe(startDate.atStartOfDay());
-        } else if (endDate != null) {
-            return createdAt.loe(endDate.atStartOfDay());
-        }
-        return null; // 조건이 없으면 null 반환
-    }
+	// 날짜 필터 조건
+	private BooleanExpression filterByDate(LocalDate startDate, LocalDate endDate) {
+		DateTimePath<LocalDateTime> createdAt = seed.createdAt;
 
-    // 저장 형식 필터 조건
-    private BooleanExpression filterByStorageFormat(List<String> seedType) {
-        if (seedType == null || seedType.isEmpty()) {
-            return null;
-        }
+		if (startDate != null && endDate != null) {
+			if (startDate.equals(endDate)) {
+				return createdAt.between(startDate.atStartOfDay(), startDate.atStartOfDay().plusDays(1));
+			}
+			return createdAt.between(startDate.atStartOfDay(), endDate.atStartOfDay());
+		} else if (startDate != null) {
+			return createdAt.goe(startDate.atStartOfDay());
+		} else if (endDate != null) {
+			return createdAt.loe(endDate.atStartOfDay());
+		}
+		return null; // 조건이 없으면 null 반환
+	}
 
-        BooleanExpression expression = null;
+	// 저장 형식 필터 조건
+	private BooleanExpression filterByStorageFormat(List<String> seedType) {
+		if (seedType == null || seedType.isEmpty()) {
+			return null;
+		}
 
-        for (String typeStr : seedType) {
-            try {
-                SeedType type = SeedType.valueOf(typeStr);
-                BooleanExpression condition = seed.seedType.eq(type);
-                expression = (expression == null) ? condition : expression.or(condition);
-            } catch (IllegalArgumentException e) {
-                throw SeedzipException.from(ErrorCode.SEED_TYPE_NOT_SUPPORTED);
-            }
-        }
+		BooleanExpression expression = null;
 
-        return expression;
-    }
+		for (String typeStr : seedType) {
+			try {
+				SeedType type = SeedType.valueOf(typeStr);
+				BooleanExpression condition = seed.seedType.eq(type);
+				expression = (expression == null) ? condition : expression.or(condition);
+			} catch (IllegalArgumentException e) {
+				throw SeedzipException.from(ErrorCode.SEED_TYPE_NOT_SUPPORTED);
+			}
+		}
 
-    // D-Day 필터 조건
-    private BooleanExpression filterByDDay(Long fromDDay, Long toDDay) {
+		return expression;
+	}
 
-        if (fromDDay != null && toDDay != null) {
-            if(fromDDay.equals(toDDay)) {	// D-Day가 같은 경우
-                return seed.dDay.eq(LocalDate.now().plusDays(fromDDay));
-            }
-            return seed.dDay.between(LocalDate.now().plusDays(fromDDay), LocalDate.now().plusDays(toDDay));
-        } else if (fromDDay != null) {
-            return seed.dDay.goe(LocalDate.now().plusDays(fromDDay));	// D-Day 시작 범위
-        } else if (toDDay != null) {
-            return seed.dDay.loe(LocalDate.now().plusDays(toDDay));	// D-Day 끝 범위
-        }
-        return null;
-    }
+	// D-Day 필터 조건
+	private BooleanExpression filterByDDay(Long fromDDay, Long toDDay) {
 
-    private BooleanExpression filterByTags(Long filterId) {
-        if (filterId == null) return null;
+		if (fromDDay != null && toDDay != null) {
+			if (fromDDay.equals(toDDay)) {    // D-Day가 같은 경우
+				return seed.dDay.eq(LocalDate.now().plusDays(fromDDay));
+			}
+			return seed.dDay.between(LocalDate.now().plusDays(fromDDay), LocalDate.now().plusDays(toDDay));
+		} else if (fromDDay != null) {
+			return seed.dDay.goe(LocalDate.now().plusDays(fromDDay));    // D-Day 시작 범위
+		} else if (toDDay != null) {
+			return seed.dDay.loe(LocalDate.now().plusDays(toDDay));    // D-Day 끝 범위
+		}
+		return null;
+	}
 
-        // 1. 필터에 포함된 태그 ID 리스트 조회
-        List<Long> tagIds = queryFactory
-            .select(filterTag.tag.id)
-            .from(filterTag)
-            .where(filterTag.filter.filterId.eq(filterId))
-            .fetch();
+	private BooleanExpression filterByTags(Long filterId) {
+		if (filterId == null)
+			return null;
 
-        if (tagIds.isEmpty()) return null;
+		// 1. 필터에 포함된 태그 ID 리스트 조회
+		List<Long> tagIds = queryFactory
+			.select(filterTag.tag.id)
+			.from(filterTag)
+			.where(filterTag.filter.filterId.eq(filterId))
+			.fetch();
 
-        // 2. seedTag를 inner join하여 해당 태그들을 모두 포함하는 Seed만 조회
-        return seed.id.in(
-            queryFactory
-                .selectDistinct(seedTag.seed.id)
-                .from(seedTag)
-                .where(seedTag.tag.id.in(tagIds))
-                .groupBy(seedTag.seed.id)
-                .having(seedTag.tag.id.countDistinct().goe((long) tagIds.size()))
-        );
-    }
+		if (tagIds.isEmpty())
+			return null;
 
-    // 정렬 조건 변환
-    private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
-        List<OrderSpecifier<?>> orders = new ArrayList<>();
+		// 2. seedTag를 inner join하여 해당 태그들을 모두 포함하는 Seed만 조회
+		return seed.id.in(
+			queryFactory
+				.selectDistinct(seedTag.seed.id)
+				.from(seedTag)
+				.where(seedTag.tag.id.in(tagIds))
+				.groupBy(seedTag.seed.id)
+				.having(seedTag.tag.id.countDistinct().goe((long)tagIds.size()))
+		);
+	}
 
-        for (Sort.Order order : sort) {
-            String sortBy = order.getProperty(); // ex) "latest" or "name"
-            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+	// 정렬 조건 변환
+	private OrderSpecifier<?>[] getOrderSpecifiers(Sort sort) {
+		List<OrderSpecifier<?>> orders = new ArrayList<>();
 
-            switch (sortBy) {
-                case "createdAt" -> orders.add(new OrderSpecifier<>(direction, seed.createdAt));
-                case "seedName" -> orders.add(new OrderSpecifier<>(direction, seed.seedName));
-                default -> System.out.println("정렬 무시됨: " + sortBy);
-            }
-        }
+		for (Sort.Order order : sort) {
+			String sortBy = order.getProperty(); // ex) "latest" or "name"
+			Order direction = order.isAscending() ? Order.ASC : Order.DESC;
 
-        return orders.toArray(new OrderSpecifier[0]);
-    }
+			switch (sortBy) {
+				case "createdAt" -> orders.add(new OrderSpecifier<>(direction, seed.createdAt));
+				case "seedName" -> orders.add(new OrderSpecifier<>(direction, seed.seedName));
+				default -> System.out.println("정렬 무시됨: " + sortBy);
+			}
+		}
 
-    private BooleanExpression safeAnd(BooleanExpression base, BooleanExpression condition) {
-        return condition == null ? base : base.and(condition);
-    }
+		return orders.toArray(new OrderSpecifier[0]);
+	}
+
+	private BooleanExpression safeAnd(BooleanExpression base, BooleanExpression condition) {
+		return condition == null ? base : base.and(condition);
+	}
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedCacheService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedCacheService.java
@@ -9,9 +9,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class SeedCacheService {
 
-	@Autowired private RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, Object> redisTemplate;
 
 	private static final String SEED_VIEWS_KEY = "seed-views";
+
+	public SeedCacheService(RedisTemplate<String, Object> redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
 
 	public void increaseViewCounts(Long seedId) {
 		redisTemplate.opsForHash().increment(SEED_VIEWS_KEY, seedId.toString(), 1);

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedCacheService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedCacheService.java
@@ -1,0 +1,27 @@
+package com.adoonge.seedzip.seed.service;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SeedCacheService {
+
+	@Autowired private RedisTemplate<String, Object> redisTemplate;
+
+	private static final String SEED_VIEWS_KEY = "seed-views";
+
+	public void increaseViewCounts(Long seedId) {
+		redisTemplate.opsForHash().increment(SEED_VIEWS_KEY, seedId.toString(), 1);
+	}
+
+	public Map<Object, Object> getAllViewCounts() {
+		return redisTemplate.opsForHash().entries(SEED_VIEWS_KEY);
+	}
+
+	public void clearAllViewCounts() {
+		redisTemplate.delete(SEED_VIEWS_KEY);
+	}
+}

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedScheduledService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedScheduledService.java
@@ -17,7 +17,7 @@ public class SeedScheduledService {
 	private final SeedCacheService seedCacheService;
 	private final SeedRepository seedRepository;
 
-	@Scheduled(cron = "0 */30 * * * *") // 매 30분마다 실행
+	@Scheduled(cron = "*/30 * * * * *") // 30초마다 실행
 	@Transactional
 	public void syncSeedViewCount() {
 		// 캐시에서 시드 조회수 가져오기

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedScheduledService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedScheduledService.java
@@ -1,0 +1,40 @@
+package com.adoonge.seedzip.seed.service;
+
+import java.util.Map;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.adoonge.seedzip.seed.repository.SeedRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SeedScheduledService {
+
+	private final SeedCacheService seedCacheService;
+	private final SeedRepository seedRepository;
+
+	@Scheduled(cron = "0 */30 * * * *") // 매 30분마다 실행
+	@Transactional
+	public void syncSeedViewCount() {
+		// 캐시에서 시드 조회수 가져오기
+		Map<Object, Object> allViewCounts = seedCacheService.getAllViewCounts();
+		if (allViewCounts == null || allViewCounts.isEmpty()) {
+			return; // 캐시에 조회수가 없으면 종료
+		}
+
+		// 시드 조회수 업데이트
+		allViewCounts.forEach((k, v) -> {
+			Long seedId = Long.parseLong(k.toString());
+			Long viewCount = v == null ? 0L : Long.parseLong(v.toString());
+			seedRepository.incrementViews(seedId, viewCount);
+		});
+
+		// 캐시 초기화
+		seedCacheService.clearAllViewCounts();
+	}
+
+}

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -60,6 +60,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class SeedService {
 
 	private final FileService fileService;
+	private final SeedCacheService seedCacheService;
 
 	private final SeedRepository seedRepository;
 	private final FileRepository fileRepository;
@@ -204,8 +205,9 @@ public class SeedService {
 	}
 
 	@Transactional(readOnly = true)
-	public SeedResponse.SeedDetail getSeedDetail(Long seedId, Member member) {
+	public SeedResponse.SeedDetail getSeedDetail(Long seedId) {
 		Seed seed = getSeedOrThrow(seedId);
+		seedCacheService.increaseViewCounts(seedId);
 		List<File> files = fileRepository.findAllBySeed(seed)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,3 +101,8 @@ server:
   tomcat:
     max-swallow-size: 50MB
   url: ${SERVER_URL}
+
+data:
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,7 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}
 
 # logging
 logging:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,6 +36,11 @@ spring:
       max-file-size: 15MB
       max-request-size: 15MB
 
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+
 # logging
 logging:
   level:
@@ -101,8 +106,3 @@ server:
   tomcat:
     max-swallow-size: 50MB
   url: ${SERVER_URL}
-
-data:
-  redis:
-    host: ${REDIS_HOST}
-    port: ${REDIS_PORT}


### PR DESCRIPTION
## 🪺 Summary

- Redis 캐시 사용 세팅
- 조회수 증가 로직 구현
<img width="265" alt="스크린샷 2025-05-26 오후 5 12 50" src="https://github.com/user-attachments/assets/29a4eefd-874f-4128-93a0-396714abe64d" /><img width="527" alt="스크린샷 2025-05-26 오후 5 15 33" src="https://github.com/user-attachments/assets/113d6bdb-856f-4ac0-ac49-f5087e32b7d6" />
위의 터미널 화면이 redis-cli 접속해서 seedId, 조회수를 조회한 사진이고, 아래처럼 30분마다 디비에 반영합니다
- 앱 메인페이지를 위한 유저 씨드 정보 반환 : 일단 이건 app용 api를 따로 생성했습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #141 

## 🙏 To Reviewers
서버에도 Redis 설정을 해야해서 건드릴게 좀 있을 것 같습니다!