### PR TITLE
[Feat] 많이읽은씨드, 읽지않은 씨드 관련 구현 (#150)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -109,6 +109,7 @@ public enum ErrorCode {
     SEED_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크된 씨드를 찾을 수 없습니다."),
     SEED_BOOKMARK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "북마크된 씨드에 대한 접근 권한이 없습니다."),
     EMPTY_SEED(HttpStatus.OK, "씨드가 존재하지 않습니다."),
+    SEED_ACCESS_DENIED(HttpStatus.FORBIDDEN, "이 씨드에 대한 접근 권한이 없습니다."),
 
     // tag
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다."),

--- a/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
+++ b/src/main/java/com/adoonge/seedzip/global/exception/ErrorCode.java
@@ -108,9 +108,7 @@ public enum ErrorCode {
     SEED_ALREADY_BOOKMARKED(HttpStatus.CONFLICT, "이미 북마크된 씨드입니다."),
     SEED_BOOKMARK_NOT_FOUND(HttpStatus.NOT_FOUND, "북마크된 씨드를 찾을 수 없습니다."),
     SEED_BOOKMARK_ACCESS_DENIED(HttpStatus.FORBIDDEN, "북마크된 씨드에 대한 접근 권한이 없습니다."),
-
-
-
+    EMPTY_SEED(HttpStatus.OK, "씨드가 존재하지 않습니다."),
 
     // tag
     TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "태그를 찾을 수 없습니다."),

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -1,6 +1,6 @@
 package com.adoonge.seedzip.seed.controller;
 
-import com.adoonge.seedzip.content.dto.response.ContentsAllResponse;
+import com.adoonge.seedzip.seed.dto.request.SeedDeleteListRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedUpdateRequest;
 import com.adoonge.seedzip.seed.dto.response.SeedResponse.GetFilteredSeeds;
@@ -230,6 +230,52 @@ public class SeedController {
         SeedResponse.SeedInfoSimple seedInfoSimple = seedService.updateSeed(request, seedId, member);
 
         return new ApiResponse<>(seedInfoSimple);
+    }
+
+    @GetMapping(value = "/popular")
+    @Operation(summary = "많이 찾는 씨드 조회", description = "많이 찾는 씨드 목록을 조회하는 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.GetAllSeeds> getPopularSeeds(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+        // 인기 씨드 조회
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+    }
+
+    @GetMapping(value = "/unread")
+    @Operation(summary = "읽지 않은 씨드 조회", description = "한번도 읽지 않은 씨드 목록을 조회하는 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.GetAllSeeds> getUnreadSeeds(
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+        // 읽지 않은 씨드 조회
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+    }
+
+    @DeleteMapping(value = "/unread")
+    @Operation(summary = "읽지 않은 씨드 선택 삭제", description = "한번도 읽지 않은 씨드 목록을 선택적으로 삭제하는 API입니다.")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+            content = @Content(mediaType = "application/json",
+                schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<Void> deleteUnreadSeeds(
+        @RequestBody @Valid SeedDeleteListRequest request,
+        @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Member member = customUserDetails.getMember();
+        // 읽지 않은 씨드 선택 삭제
+        return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 
 }

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -233,7 +233,8 @@ public class SeedController {
     }
 
     @GetMapping(value = "/popular")
-    @Operation(summary = "많이 찾는 씨드 조회", description = "많이 찾는 씨드 목록을 조회하는 API입니다.")
+    @Operation(summary = "많이 찾는 씨드 조회", description = "많이 찾는 씨드 목록을 조회하는 API입니다."
+        + "조회수가 3회 이상인 씨드 중 조회수가 높은순으로 30개를 반환합니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
             content = @Content(mediaType = "application/json",
@@ -241,10 +242,12 @@ public class SeedController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ApiResponse<SeedResponse.GetAllSeeds> getPopularSeeds(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "9") int size,
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Member member = customUserDetails.getMember();
-        // 인기 씨드 조회
-        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+        SeedResponse.GetAllSeeds popularSeeds = seedService.getPopularSeeds(page, size, member);
+        return new ApiResponse<>(popularSeeds);
     }
 
     @GetMapping(value = "/unread")

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -267,19 +267,19 @@ public class SeedController {
         return new ApiResponse<>(unreadSeeds);
     }
 
-    @DeleteMapping(value = "/unread")
-    @Operation(summary = "읽지 않은 씨드 선택 삭제", description = "한번도 읽지 않은 씨드 목록을 선택적으로 삭제하는 API입니다.")
+    @DeleteMapping(value = "/list")
+    @Operation(summary = "씨드 목록 선택 삭제", description = "씨드 목록을 request에 포함하여 여러개의 씨드를 선택 삭제하는 API입니다.")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
             content = @Content(mediaType = "application/json",
                 schema = @Schema(implementation = SeedResponse.GetAllSeeds.class))),
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
-    public ApiResponse<Void> deleteUnreadSeeds(
+    public ApiResponse<Void> deleteSeedList(
         @RequestBody @Valid SeedDeleteListRequest request,
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Member member = customUserDetails.getMember();
-        // 읽지 않은 씨드 선택 삭제
+        seedService.deleteSeedList(request, member);
         return new ApiResponse<>(ErrorCode.REQUEST_OK);
     }
 

--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -259,10 +259,12 @@ public class SeedController {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
     })
     public ApiResponse<SeedResponse.GetAllSeeds> getUnreadSeeds(
+        @RequestParam(defaultValue = "0") int page,
+        @RequestParam(defaultValue = "9") int size,
         @AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Member member = customUserDetails.getMember();
-        // 읽지 않은 씨드 조회
-        return new ApiResponse<>(ErrorCode.REQUEST_OK);
+        SeedResponse.GetAllSeeds unreadSeeds = seedService.getUnreadSeeds(member, page, size);
+        return new ApiResponse<>(unreadSeeds);
     }
 
     @DeleteMapping(value = "/unread")

--- a/src/main/java/com/adoonge/seedzip/seed/dto/request/SeedDeleteListRequest.java
+++ b/src/main/java/com/adoonge/seedzip/seed/dto/request/SeedDeleteListRequest.java
@@ -1,0 +1,8 @@
+package com.adoonge.seedzip.seed.dto.request;
+
+import java.util.List;
+
+public record SeedDeleteListRequest (
+	List<Long> seedIdList
+){
+}

--- a/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/CategorySeedRepository.java
@@ -26,4 +26,6 @@ public interface CategorySeedRepository extends JpaRepository<CategorySeed, Long
     List<CategorySeedProjection> findCategoryInfoBySeedIds(@Param("seedIds") List<Long> seedIds);
 
     void deleteAllBySeedId(Long seedId);
+
+    void deleteAllBySeedIdIn(List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/FileRepository.java
@@ -25,5 +25,7 @@ public interface FileRepository extends JpaRepository<File, Long> {
 
     void deleteAllBySeedId(Long seedId);
 
+    void deleteAllBySeedIdIn(List<Long> seedIds);
+
     List<File> findFilesBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -37,4 +37,6 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 	void incrementViews(@Param("seedId") Long seedId, @Param("count") Long count);
 
 	long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
+
+	Page<Seed> findTop30ByMemberAndViewCountGreaterThanOrderByViewCountDesc(Member member, Long viewCount, Pageable pageable);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -14,8 +14,11 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
 import jakarta.transaction.Transactional;
 
+@Repository
 public interface SeedRepository extends JpaRepository<Seed, Long> {
 	Page<Seed> findByMember(Member member, Pageable pageable);
 
@@ -41,4 +44,8 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 	Page<Seed> findTop30ByMemberAndViewCountGreaterThanOrderByViewCountDesc(Member member, Long viewCount, Pageable pageable);
 
 	Page<Seed> findByMemberAndViewCount(Member member, Long viewCount, Pageable pageable);
+
+	List<Seed> findAllByIdIn(List<Long> seedIds);
+
+	void deleteAllByIdIn(List<Long> seedIds);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepository.java
@@ -39,4 +39,6 @@ public interface SeedRepository extends JpaRepository<Seed, Long> {
 	long countByCreatedAtBetween(LocalDateTime from, LocalDateTime to);
 
 	Page<Seed> findTop30ByMemberAndViewCountGreaterThanOrderByViewCountDesc(Member member, Long viewCount, Pageable pageable);
+
+	Page<Seed> findByMemberAndViewCount(Member member, Long viewCount, Pageable pageable);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedTagRepository.java
@@ -24,5 +24,7 @@ public interface SeedTagRepository extends JpaRepository<SeedTag, Long> {
 
     void deleteAllBySeedId(Long seedId);
 
+    void deleteAllBySeedIdIn(List<Long> seedIds);
+
     List<SeedTag> findSeedTagsBySeedId(Long seedId);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -103,7 +103,7 @@ public class SeedService {
 		}
 
 		if(seedList.isEmpty()){
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetAllSeedsResponse(member, seedList);
 	}
@@ -129,7 +129,7 @@ public class SeedService {
 		}
 
 		if (seedList.isEmpty()){
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetAllSeedsResponse(member, seedList);
 	}
@@ -164,7 +164,7 @@ public class SeedService {
 	@Transactional
 	public void uploadFiles(Long seedId, List<MultipartFile> files) {
 		Seed seed = seedRepository.findById(seedId).orElseThrow(
-			() -> SeedzipException.from(ErrorCode.CONTENT_NOT_FOUND)
+			() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND)
 		);
 
 		fileService.saveFiles(files, seed);
@@ -174,7 +174,7 @@ public class SeedService {
 		Seed seed = getSeedOrThrow(seedId);
 		seedCacheService.increaseViewCounts(seedId);
 		List<File> files = fileRepository.findAllBySeed(seed)
-				.orElseThrow(() -> SeedzipException.from(ErrorCode.SEED_NOT_FOUND));
+				.orElseThrow(() -> SeedzipException.from(ErrorCode.FILE_NOT_FOUND));
 
 		String seedLink = null;
 		List<String> fileLinks = null;
@@ -237,7 +237,7 @@ public class SeedService {
 		}
 
 		if (seedList.isEmpty()){
-			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
@@ -260,7 +260,7 @@ public class SeedService {
 		}
 
 		if (seedList.isEmpty()){
-			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
@@ -280,7 +280,7 @@ public class SeedService {
 		List<Seed> seedList = seedPage.getContent();
 
 		if (seedList.isEmpty()){
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetFilteredSeedsResponse(member, seedPage);
 	}
@@ -398,7 +398,7 @@ public class SeedService {
 		}
 
 		if (seedList.isEmpty()){
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetAllSeedsResponse(member, seedList);
 	}
@@ -410,7 +410,7 @@ public class SeedService {
 			pageable);
 
 		if( popularSeeds.isEmpty() ) {
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetAllSeedsResponse(member, popularSeeds);
 	}
@@ -420,7 +420,7 @@ public class SeedService {
 		Page<Seed> seedList = seedRepository.findByMemberAndViewCount(member, UNREAD_VIEW_COUNT, pageable);
 
 		if (seedList.isEmpty()) {
-			return null;
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
 		}
 		return buildGetAllSeedsResponse(member, seedList);
 	}

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -1,7 +1,6 @@
 package com.adoonge.seedzip.seed.service;
 
 import com.adoonge.seedzip.bookmark.repository.SeedBookmarkRepository;
-import com.adoonge.seedzip.bookmark.service.BookmarkService;
 import com.adoonge.seedzip.category.domain.Category;
 import com.adoonge.seedzip.category.repository.CategoryRepository;
 import com.adoonge.seedzip.filter.domain.Filter;
@@ -38,12 +37,10 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -103,34 +100,10 @@ public class SeedService {
 			seedList = seedRepository.findByMember(member, pageable);
 		}
 
-		if (seedList.isEmpty())
+		if(seedList.isEmpty()){
 			return null;
-
-		// seedId 리스트 추출
-		List<Long> seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
-
-		//페이징 정보 추가
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-			.page(seedList.getNumber())
-			.size(seedList.getSize())
-			.totalPages(seedList.getTotalPages())
-			.totalElements(seedList.getTotalElements())
-			.isLast(seedList.isLast())
-			.build();
-
-		return SeedResponse.GetAllSeeds.builder()
-			.nickname(member.getNickname())
-			.seedInfoList(seedInfoList)
-			.pageInfo(pageInfo)
-			.build();
+		}
+		return buildGetAllSeedsResponse(member, seedList);
 	}
 
 	public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
@@ -153,34 +126,10 @@ public class SeedService {
 			seedList = seedRepository.findBySeedIdIn(seedIds, pageable);
 		}
 
-		if (seedList.isEmpty())
+		if (seedList.isEmpty()){
 			return null;
-
-		// seedId 리스트 추출
-		seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
-
-		//페이징 정보 추가
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-			.page(seedList.getNumber())
-			.size(seedList.getSize())
-			.totalPages(seedList.getTotalPages())
-			.totalElements(seedList.getTotalElements())
-			.isLast(seedList.isLast())
-			.build();
-
-		return SeedResponse.GetAllSeeds.builder()
-			.nickname(member.getNickname())
-			.seedInfoList(seedInfoList)
-			.pageInfo(pageInfo)
-			.build();
+		}
+		return buildGetAllSeedsResponse(member, seedList);
 	}
 
 	@Transactional
@@ -288,32 +237,7 @@ public class SeedService {
 		if (seedList.isEmpty()){
 			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
 		}
-
-		// seedId 리스트 추출
-		List<Long> seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
-
-		//페이징 정보 추가
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-				.page(seedList.getNumber())
-				.size(seedList.getSize())
-				.totalPages(seedList.getTotalPages())
-				.totalElements(seedList.getTotalElements())
-				.isLast(seedList.isLast())
-				.build();
-
-		return SeedResponse.GetFilteredSeeds.builder()
-				.nickname(member.getNickname())
-				.seedInfoList(seedInfoList)
-				.pageInfo(pageInfo)
-				.build();
+		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
 	public SeedResponse.GetFilteredSeeds getFilteredCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
@@ -336,32 +260,7 @@ public class SeedService {
 		if (seedList.isEmpty()){
 			throw SeedzipException.from(ErrorCode.SEED_NOT_FOUND);
 		}
-
-		// seedId 리스트 추출
-		List<Long> seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
-
-		//페이징 정보 추가
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-				.page(seedList.getNumber())
-				.size(seedList.getSize())
-				.totalPages(seedList.getTotalPages())
-				.totalElements(seedList.getTotalElements())
-				.isLast(seedList.isLast())
-				.build();
-
-		return SeedResponse.GetFilteredSeeds.builder()
-				.nickname(member.getNickname())
-				.seedInfoList(seedInfoList)
-				.pageInfo(pageInfo)
-				.build();
+		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
 	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
@@ -378,34 +277,10 @@ public class SeedService {
 				filter.getStorageFormats(), filter.getFromDDay(), filter.getToDDay(), filter.getFilterId(), member.getId());
 		List<Seed> seedList = seedPage.getContent();
 
-		if (seedList.isEmpty())
+		if (seedList.isEmpty()){
 			return null;
-
-		// seedId 리스트 추출
-		List<Long> seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoWithSeedDetails = generateResponseWithDetailFromSeedList(seedList, seedProjectionResult, bookmarkedSeedSet);
-
-
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-				.page(seedPage.getNumber())
-				.size(seedPage.getSize())
-				.totalPages(seedPage.getTotalPages())
-				.totalElements(seedPage.getTotalElements())
-				.isLast(seedPage.isLast())
-				.build();
-
-		return SeedResponse.GetFilteredSeeds.builder()
-				.nickname(member.getNickname())
-				.seedInfoList(seedInfoWithSeedDetails)
-				.pageInfo(pageInfo)
-				.build();
+		}
+		return buildGetFilteredSeedsResponse(member, seedPage);
 	}
 
 	@Transactional
@@ -520,34 +395,10 @@ public class SeedService {
 			seedList = seedRepository.findBySeedIdIn(seedIds, pageable);
 		}
 
-		if (seedList.isEmpty())
+		if (seedList.isEmpty()){
 			return null;
-
-		// seedId 리스트 추출
-		seedIds = seedList.stream()
-				.map(Seed::getId)
-				.toList();
-
-		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
-
-		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
-
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
-
-		//페이징 정보 추가
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-				.page(seedList.getNumber())
-				.size(seedList.getSize())
-				.totalPages(seedList.getTotalPages())
-				.totalElements(seedList.getTotalElements())
-				.isLast(seedList.isLast())
-				.build();
-
-		return SeedResponse.GetAllSeeds.builder()
-				.nickname(member.getNickname())
-				.seedInfoList(seedInfoList)
-				.pageInfo(pageInfo)
-				.build();
+		}
+		return buildGetAllSeedsResponse(member, seedList);
 	}
 
 	public SeedResponse.GetAllSeeds getPopularSeeds(int page, int size, Member member){
@@ -556,29 +407,58 @@ public class SeedService {
 			member, DEFAULT_VIEW_COUNT,
 			pageable);
 
-		if (popularSeeds.isEmpty())
+		if( popularSeeds.isEmpty() ) {
 			return null;
+		}
+		return buildGetAllSeedsResponse(member, popularSeeds);
+	}
 
-		List<Long> seedIds = popularSeeds.stream().map(Seed::getId).toList();
+	private SeedResponse.GetAllSeeds buildGetAllSeedsResponse(Member member, Page<Seed> seedList) {
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+			.map(Seed::getId)
+			.toList();
+
+		// seedId 리스트로 SeedProjectionResult 생성
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
+		// 북마크된 씨드 ID 리스트를 Set으로 변환
+		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
+		// SeedResponse.SeedInfo 리스트 생성
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
+
+		return SeedResponse.GetAllSeeds.builder()
+			.nickname(member.getNickname())
+			.seedInfoList(seedInfoList)
+			.pageInfo(fromPage(seedList))
+			.build();
+	}
+
+	private SeedResponse.GetFilteredSeeds buildGetFilteredSeedsResponse(Member member, Page<Seed> seedList) {
+		// seedId 리스트 추출
+		List<Long> seedIds = seedList.stream()
+			.map(Seed::getId)
+			.toList();
 
 		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
 
 		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
 
-		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(popularSeeds.getContent(), seedProjectionResult, bookmarkedSeedSet);
+		List<SeedResponse.SeedInfoWithSeedDetail> seedInfoList = generateResponseWithDetailFromSeedList(seedList.getContent(), seedProjectionResult, bookmarkedSeedSet);
 
-		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
-			.page(popularSeeds.getNumber())
-			.size(popularSeeds.getSize())
-			.totalPages(popularSeeds.getTotalPages())
-			.totalElements(popularSeeds.getTotalElements())
-			.isLast(popularSeeds.isLast())
-			.build();
-
-		return SeedResponse.GetAllSeeds.builder()
+		return SeedResponse.GetFilteredSeeds.builder()
 			.nickname(member.getNickname())
 			.seedInfoList(seedInfoList)
-			.pageInfo(pageInfo)
+			.pageInfo(fromPage(seedList))
+			.build();
+	}
+
+	private static SeedResponse.PageInfo fromPage(Page<Seed> seedList) {
+		return SeedResponse.PageInfo.builder()
+			.page(seedList.getNumber())
+			.size(seedList.getSize())
+			.totalPages(seedList.getTotalPages())
+			.totalElements(seedList.getTotalElements())
+			.isLast(seedList.isLast())
 			.build();
 	}
 

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -83,6 +83,8 @@ public class SeedService {
 		.map(DefaultTagType::getDisplayName)
 		.collect(Collectors.toSet());
 
+	private static final Long DEFAULT_VIEW_COUNT = 3L;
+
 	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType) {
 
@@ -546,6 +548,38 @@ public class SeedService {
 				.seedInfoList(seedInfoList)
 				.pageInfo(pageInfo)
 				.build();
+	}
+
+	public SeedResponse.GetAllSeeds getPopularSeeds(int page, int size, Member member){
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Seed> popularSeeds = seedRepository.findTop30ByMemberAndViewCountGreaterThanOrderByViewCountDesc(
+			member, DEFAULT_VIEW_COUNT,
+			pageable);
+
+		if (popularSeeds.isEmpty())
+			return null;
+
+		List<Long> seedIds = popularSeeds.stream().map(Seed::getId).toList();
+
+		SeedProjectionResult seedProjectionResult = getSeedProjectionResult(seedIds);
+
+		Set<Long> bookmarkedSeedSet = new HashSet<>(seedBookmarkRepository.findSeedIdsByMember(member));
+
+		List<SeedResponse.SeedInfo> seedInfoList = generateResponseFromSeedList(popularSeeds.getContent(), seedProjectionResult, bookmarkedSeedSet);
+
+		SeedResponse.PageInfo pageInfo = SeedResponse.PageInfo.builder()
+			.page(popularSeeds.getNumber())
+			.size(popularSeeds.getSize())
+			.totalPages(popularSeeds.getTotalPages())
+			.totalElements(popularSeeds.getTotalElements())
+			.isLast(popularSeeds.isLast())
+			.build();
+
+		return SeedResponse.GetAllSeeds.builder()
+			.nickname(member.getNickname())
+			.seedInfoList(seedInfoList)
+			.pageInfo(pageInfo)
+			.build();
 	}
 
 	private SeedProjectionResult getSeedProjectionResult(List<Long> seedIds) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -18,6 +18,7 @@ import com.adoonge.seedzip.seed.dto.projection.CategorySeedProjection;
 import com.adoonge.seedzip.seed.dto.projection.FileSeedProjection;
 import com.adoonge.seedzip.seed.dto.projection.SeedProjectionResult;
 import com.adoonge.seedzip.seed.dto.projection.SeedTagProjection;
+import com.adoonge.seedzip.seed.dto.request.SeedDeleteListRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedFilteringRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedRequest;
 import com.adoonge.seedzip.seed.dto.request.SeedUpdateRequest;
@@ -422,6 +423,16 @@ public class SeedService {
 			return null;
 		}
 		return buildGetAllSeedsResponse(member, seedList);
+	}
+
+	@Transactional
+	public void deleteSeedList(SeedDeleteListRequest request, Member member) {
+		List<Long> seedIds = request.seedIdList();
+		if (seedIds.isEmpty())	return;
+
+		for (Long seedId : seedIds) {
+			deleteSeed(seedId, member);
+		}
 	}
 
 	private SeedResponse.GetAllSeeds buildGetAllSeedsResponse(Member member, Page<Seed> seedList) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -81,6 +81,7 @@ public class SeedService {
 		.collect(Collectors.toSet());
 
 	private static final Long DEFAULT_VIEW_COUNT = 3L;
+	private static final Long UNREAD_VIEW_COUNT = 0L;
 
 	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType) {
@@ -411,6 +412,16 @@ public class SeedService {
 			return null;
 		}
 		return buildGetAllSeedsResponse(member, popularSeeds);
+	}
+
+	public SeedResponse.GetAllSeeds getUnreadSeeds(Member member, int page, int size) {
+		Pageable pageable = PageRequest.of(page, size);
+		Page<Seed> seedList = seedRepository.findByMemberAndViewCount(member, UNREAD_VIEW_COUNT, pageable);
+
+		if (seedList.isEmpty()) {
+			return null;
+		}
+		return buildGetAllSeedsResponse(member, seedList);
 	}
 
 	private SeedResponse.GetAllSeeds buildGetAllSeedsResponse(Member member, Page<Seed> seedList) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -59,6 +59,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 @Slf4j
@@ -82,7 +83,6 @@ public class SeedService {
 		.map(DefaultTagType::getDisplayName)
 		.collect(Collectors.toSet());
 
-	@Transactional(readOnly = true)
 	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType) {
 
@@ -131,7 +131,6 @@ public class SeedService {
 			.build();
 	}
 
-	@Transactional(readOnly = true)
 	public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType, long categoryId) {
 
@@ -218,7 +217,6 @@ public class SeedService {
 		fileService.saveFiles(files, seed);
 	}
 
-	@Transactional(readOnly = true)
 	public SeedResponse.SeedDetail getSeedDetail(Long seedId) {
 		Seed seed = getSeedOrThrow(seedId);
 		seedCacheService.increaseViewCounts(seedId);
@@ -268,7 +266,6 @@ public class SeedService {
 				.build();
 	}
 
-	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getFilteredSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 														  String seedType, SeedFilteringRequest request) {
 		Sort.Direction direction = getSortDirection(isAsc);
@@ -317,7 +314,6 @@ public class SeedService {
 				.build();
 	}
 
-	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getFilteredCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 														  String seedType, Long categoryId, SeedFilteringRequest request) {
 		Sort.Direction direction = getSortDirection(isAsc);
@@ -366,7 +362,6 @@ public class SeedService {
 				.build();
 	}
 
-	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
 		Filter filter = filterRepository.findById(filterId)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -299,10 +299,7 @@ public class SeedService {
 		categorySeedRepository.deleteAllBySeedId(id);
 
 		//S3에서 파일 삭제
-		List<String> fileLinks = fileRepository.findFilesBySeedId(id).stream()
-			.map(File::getLink)
-			.toList();
-		fileService.deleteFiles(seed.getSeedType(), fileLinks);
+		deleteFileFromS3(id, seed);
 
 		//파일 삭제
 		fileRepository.deleteAllBySeedId(id);
@@ -361,11 +358,7 @@ public class SeedService {
 				file.updateLink(request.seedLink());
 			}
 		} else {    // 이미지, PDF
-			List<String> fileLinks = fileRepository.findFilesBySeedId(seedId).stream()
-				.map(File::getLink)
-				.toList();
-			fileService.deleteFiles(seed.getSeedType(), fileLinks);
-
+			deleteFileFromS3(seedId, seed);
 			fileRepository.deleteAllBySeedId(seedId);
 		}
 
@@ -430,9 +423,30 @@ public class SeedService {
 		List<Long> seedIds = request.seedIdList();
 		if (seedIds.isEmpty())	return;
 
-		for (Long seedId : seedIds) {
-			deleteSeed(seedId, member);
+		List<Seed> seeds = seedRepository.findAllByIdIn(seedIds);
+		if(seedIds.size() != seeds.size()) {
+			throw SeedzipException.from(ErrorCode.SEED_ACCESS_DENIED);
 		}
+
+		// 소유자 검증 및 S3에서 파일 삭제
+		for(Seed seed : seeds) {
+			if(!seed.getMember().getId().equals(member.getId())) {
+				throw SeedzipException.from(ErrorCode.MEMBER_NOT_OWNER);
+			}
+			deleteFileFromS3(seed.getId(), seed);
+		}
+
+		categorySeedRepository.deleteAllBySeedIdIn(seedIds);
+		fileRepository.deleteAllBySeedIdIn(seedIds);
+		seedTagRepository.deleteAllBySeedIdIn(seedIds);
+		seedRepository.deleteAllByIdIn(seedIds);
+	}
+
+	private void deleteFileFromS3(Long id, Seed seed) {
+		List<String> fileLinks = fileRepository.findFilesBySeedId(id).stream()
+			.map(File::getLink)
+			.toList();
+		fileService.deleteFiles(seed.getSeedType(), fileLinks);
 	}
 
 	private SeedResponse.GetAllSeeds buildGetAllSeedsResponse(Member member, Page<Seed> seedList) {


### PR DESCRIPTION
## 🪺 Summary
<img width="698" alt="스크린샷 2025-06-07 오후 4 19 21" src="https://github.com/user-attachments/assets/52253661-eb94-49a9-83cb-f19464101867" />

- **많이 찾는 씨드 조회** : 사용자의 조회수 3 이상인 씨드 내림차순(조회수)으로 조회
- **읽지 않은 씨드 조회** : 사용자의 조회수가 0인 씨드 조회
- **씨드 목록 선택 삭제** : request에 씨드 id를 넣어서 전달하면 해당 씨드들 삭제하도록 구현했습니다. 추후에 읽지 않은 씨드 뿐만 아니더라도 선택 삭제는 재활용될 수 있을 것 같아서 "읽지않은" 키워드는 따로 넣지 않았습니다.
- **중복코드 메서드화** : SeedResponse.GetAllSeeds, GetFilteredSeeds 응답을 만들때 <seedId리스트 추출, 프로젝션, 북마크변환, seedinfo리스트 생성 및 빌드해서 리턴> 과정이 반복되는데 이 부분이 중복이 많은 것 같아 build~~ 메서드로 따로 뺐습니다. getAllSeeds, getCategorySeeds, getFilteredSeeds, getFilteredCategorySeeds, getCustomFilterSeeds 총 5개의 서비스 로직에서 분리하였고 테스트해서 기능에는 변동없는 것 확인했습니다.

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #150 


## 🙏 To Reviewers
