### PR TITLE
Refactor: 카테고리 조회 쿼리 수정 (#152)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
+++ b/src/main/java/com/adoonge/seedzip/category/repository/CategoryRepository.java
@@ -1,9 +1,12 @@
 package com.adoonge.seedzip.category.repository;
 
+import com.adoonge.seedzip.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.adoonge.seedzip.category.domain.Category;
@@ -11,7 +14,13 @@ import com.adoonge.seedzip.category.domain.Category;
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
-	List<Category> findAllByMemberId(Long memberId);
+	@Query("""
+        SELECT c
+        FROM Category c
+        WHERE c.member = :member
+        ORDER BY c.isDefault DESC, c.createdAt DESC
+    """)
+	List<Category> findAllByMemberOrdered(@Param("member") Member member);
 
 	Optional<Category> findByMemberIdAndName(Long memberId, String name);
 }

--- a/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
+++ b/src/main/java/com/adoonge/seedzip/category/service/CategoryService.java
@@ -69,7 +69,7 @@ public class CategoryService {
 	}
 
 	public List<CategoryResponse> getCategories(Member member) {
-		List<Category> categories = categoryRepository.findAllByMemberId(member.getId());
+		List<Category> categories = categoryRepository.findAllByMemberOrdered(member);
 
 		return categories.stream()
 			.map(CategoryResponse::fromEntity)


### PR DESCRIPTION
## 🪺 Summary
미분류 카테고리가 먼저, 나머지 카테고리는 생성일순으로 조회되도록 쿼리 수정했습니다!
Boolean 값은 DB마다 true = 1 / false = 0 처럼 해석되므로 DESC 를 주면 `isDefault`가 true인게 먼저 정렬되고, 그 후로는 
`createdAt` 기준으로 내림차순 정렬됩니다!

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #152


## 🙏 To Reviewers
