### PR TITLE
Feat: 즐겨찾기 씨드 내 검색 기능 구현 (#160)

### DIFF
--- a/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
+++ b/src/main/java/com/adoonge/seedzip/seed/controller/SeedController.java
@@ -196,6 +196,30 @@ public class SeedController {
         return new ApiResponse<>(filteredSeeds);
     }
 
+    @PostMapping("/filtering/bookmark")
+    @Operation(summary = "즐겨찾기(북마크) 씨드 검색 API", description = "즐겨찾기(북마크) 한 씨드를 검색하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공적으로 업로드됨",
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = SeedResponse.GetFilteredSeeds.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    public ApiResponse<SeedResponse.GetFilteredSeeds> getFilteredBookmarkSeeds(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "9") int size,
+            @RequestParam(defaultValue = "latest") String sortBy, // latest or name
+            @RequestParam(defaultValue = "false") boolean isAsc,
+            @RequestParam(required = false) String seedType,
+            @RequestParam String keyword,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Member member = customUserDetails.getMember();
+
+        GetFilteredSeeds filteredSeeds = seedService.getFilteredBookmarkSeeds(member, page, size, sortBy, isAsc, seedType, keyword);
+
+        return new ApiResponse<>(filteredSeeds);
+    }
+
     @DeleteMapping("/{seedId}")
     @Operation(summary = "씨드 삭제 API", description = "씨드 삭제 API입니다.")
     @ApiResponses(value = {

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryCustom.java
@@ -21,5 +21,8 @@ public interface SeedRepositoryCustom {
         List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberId
     );
 
+    Page<Seed> findBookmarkSeedsByFiltering(Member member, Pageable pageable, SeedType seedType, String keyword);
+
+
     SeedStatisticsDTO getSeedStatistics(Member member);
 }

--- a/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
+++ b/src/main/java/com/adoonge/seedzip/seed/repository/SeedRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.adoonge.seedzip.seed.repository;
 
+import com.adoonge.seedzip.bookmark.domain.QSeedBookmark;
 import com.adoonge.seedzip.filter.domain.QFilterTag;
 import com.adoonge.seedzip.global.exception.ErrorCode;
 import com.adoonge.seedzip.global.exception.SeedzipException;
@@ -41,6 +42,7 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
 	QTag tag = QTag.tag;
 	QCategorySeed categorySeed = QCategorySeed.categorySeed;
 	QFilterTag filterTag = QFilterTag.filterTag;
+	QSeedBookmark seedBookmark = QSeedBookmark.seedBookmark;
 
 	@Override
 	public SeedStatisticsDTO getSeedStatistics(Member member) {
@@ -134,6 +136,34 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
 	}
 
 	@Override
+	public Page<Seed> findBookmarkSeedsByFiltering(Member member, Pageable pageable, SeedType seedType,
+												   String keyword) {
+
+		BooleanExpression condition = seedBookmark.member.eq(member);
+
+		condition = safeAnd(condition, filteringByKeyword(keyword));
+		condition = safeAnd(condition, filteringBySeedType(seedType));
+
+		List<Seed> content = queryFactory
+				.select(seedBookmark.seed)
+				.from(seedBookmark)
+				.join(seedBookmark.seed, seed)
+				.where(condition)
+				.offset(pageable.getOffset())
+				.limit(pageable.getPageSize())
+				.orderBy(getOrderSpecifiers(pageable.getSort()))
+				.fetch();
+
+		Long total = queryFactory
+				.select(seedBookmark.count())
+				.from(seedBookmark)
+				.join(seedBookmark.seed, seed)
+				.where(condition)
+				.fetchOne();
+
+		return new PageImpl<>(content, pageable, total != null ? total : 0);	}
+
+	@Override
 	public Page<Seed> findSeedsByCustomFilter(Pageable pageable, LocalDate startDate, LocalDate endDate,
 		List<String> seedType, Long dDayStart, Long dDayEnd, Long filterId, Long memberID) {
 
@@ -180,6 +210,7 @@ public class SeedRepositoryImpl implements SeedRepositoryCustom {
 
 		return new PageImpl<>(seeds, pageable, total != null ? total : 0);
 	}
+
 
 	//Category 필터 조건
 	private BooleanExpression filteringByCategory(Long categoryId) {

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -84,6 +84,7 @@ public class SeedService {
 	private static final Long DEFAULT_VIEW_COUNT = 3L;
 	private static final Long UNREAD_VIEW_COUNT = 0L;
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetAllSeeds getAllSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType) {
 
@@ -108,6 +109,7 @@ public class SeedService {
 		return buildGetAllSeedsResponse(member, seedList);
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetAllSeeds getCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 		String seedType, long categoryId) {
 
@@ -170,6 +172,7 @@ public class SeedService {
 		fileService.saveFiles(files, seed);
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.SeedDetail getSeedDetail(Long seedId) {
 		Seed seed = getSeedOrThrow(seedId);
 		seedCacheService.increaseViewCounts(seedId);
@@ -219,6 +222,7 @@ public class SeedService {
 				.build();
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getFilteredSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 														  String seedType, SeedFilteringRequest request) {
 		Sort.Direction direction = getSortDirection(isAsc);
@@ -242,6 +246,7 @@ public class SeedService {
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getFilteredCategorySeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 														  String seedType, Long categoryId, SeedFilteringRequest request) {
 		Sort.Direction direction = getSortDirection(isAsc);
@@ -265,6 +270,7 @@ public class SeedService {
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getFilteredBookmarkSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
 																  String seedType, String keyword) {
 		Sort.Direction direction = getSortDirection(isAsc);
@@ -288,6 +294,7 @@ public class SeedService {
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
+	@Transactional(readOnly = true)
 	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
 		Filter filter = filterRepository.findById(filterId)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));

--- a/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
+++ b/src/main/java/com/adoonge/seedzip/seed/service/SeedService.java
@@ -265,6 +265,29 @@ public class SeedService {
 		return buildGetFilteredSeedsResponse(member, seedList);
 	}
 
+	public SeedResponse.GetFilteredSeeds getFilteredBookmarkSeeds(Member member, int page, int size, String sortBy, boolean isAsc,
+																  String seedType, String keyword) {
+		Sort.Direction direction = getSortDirection(isAsc);
+		String sortField = getSortField(sortBy);
+		SeedType parsedSeedType = parseSeedType(seedType);
+
+		//페이징을 위한 Pageable 객체
+		Pageable pageable = PageRequest.of(page, size, Sort.by(direction, sortField));
+
+		//페이징으로 얻어온 Seed 리스트
+		Page<Seed> seedList;
+		if (seedType != null) {
+			seedList = seedRepositoryCustom.findBookmarkSeedsByFiltering(member, pageable, parsedSeedType, keyword);
+		} else {
+			seedList = seedRepositoryCustom.findBookmarkSeedsByFiltering(member, pageable, null, keyword);
+		}
+
+		if (seedList.isEmpty()){
+			throw SeedzipException.from(ErrorCode.EMPTY_SEED);
+		}
+		return buildGetFilteredSeedsResponse(member, seedList);
+	}
+
 	public SeedResponse.GetFilteredSeeds getCustomFilterSeeds(Member member, int page, int size, Long filterId) {
 		Filter filter = filterRepository.findById(filterId)
 				.orElseThrow(() -> SeedzipException.from(ErrorCode.FILTER_NOT_FOUND));


### PR DESCRIPTION
## 🪺 Summary
즐겨찾기 씨드 내 검색 기능 구현 완료했습니다!
혹시라도 나중에 필터링 기능이 추가 될 수도 있을거 같아서 관련 필드들을 매개변수로 받되, nullable로 설정했습니다.
그리고 읽기만 진행하는 메소드에 `@Transactional(readOnly = true)` 추가했습니다!

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #160


## 🙏 To Reviewers
